### PR TITLE
feat: regenerated GAPIC for v1p1beta1

### DIFF
--- a/protos/google/cloud/speech/v1p1beta1/cloud_speech.proto
+++ b/protos/google/cloud/speech/v1p1beta1/cloud_speech.proto
@@ -230,6 +230,12 @@ message RecognitionConfig {
   // `false`, no word-level time offset information is returned. The default is
   // `false`.
   bool enable_word_time_offsets = 8;
+
+  // *Optional* Which model to select for the given request. Select the model
+  // best suited to your domain to get best results. If a model is not
+  // explicitly specified, then we auto-select a model based on the parameters
+  // in the RecognitionConfig.
+  string model = 13;
 }
 
 // Provides "hints" to the speech recognizer to favor specific words and phrases

--- a/src/v1p1beta1/doc/google/cloud/speech/v1p1beta1/doc_cloud_speech.js
+++ b/src/v1p1beta1/doc/google/cloud/speech/v1p1beta1/doc_cloud_speech.js
@@ -177,6 +177,12 @@ var StreamingRecognitionConfig = {
  *   `false`, no word-level time offset information is returned. The default is
  *   `false`.
  *
+ * @property {string} model
+ *   *Optional* Which model to select for the given request. Select the model
+ *   best suited to your domain to get best results. If a model is not
+ *   explicitly specified, then we auto-select a model based on the parameters
+ *   in the RecognitionConfig.
+ *
  * @typedef RecognitionConfig
  * @memberof google.cloud.speech.v1p1beta1
  * @see [google.cloud.speech.v1p1beta1.RecognitionConfig definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/speech/v1p1beta1/cloud_speech.proto}

--- a/system-test/speech_smoke_test_v1p1beta1.js
+++ b/system-test/speech_smoke_test_v1p1beta1.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-describe('SpeechSmokeTest', () => {
+describe('SpeechSmokeTest v1p1beta1', () => {
   it('successfully makes a call to the service', done => {
     const speech = require('../src');
 


### PR DESCRIPTION
Regenerated the code based on the updated protos.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
