### PR TITLE
update samples dependency before releasing 1.1.0

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -12,7 +12,7 @@
     "test": "repo-tools test run --cmd ava -- -T 20s --verbose system-test/*.test.js"
   },
   "dependencies": {
-    "@google-cloud/speech": "1.0.1",
+    "@google-cloud/speech": "1.1.0",
     "@google-cloud/storage": "1.4.0",
     "node-record-lpcm16": "0.3.0",
     "yargs": "10.0.3"


### PR DESCRIPTION
Turns out I bumped the version in `package.json` but not in `samples/package.json`, so fixing it now.