### PR TITLE
Remove projectId argument in samples

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@ Jason Dobry <jdobry@google.com>
 Jerjou <jerjou@users.noreply.github.com>
 Jun Mukai <mukai@google.com>
 Luke Sneeringer <lukesneeringer@google.com>
+Philippe Sultan <philippe.sultan@gmail.com>
 Pierre Fritsch <PierreFritsch@users.noreply.github.com>
 Puneith Kaul <puneith@google.com>
 Rebecca Taylor <remilytaylor@gmail.com>

--- a/README.md
+++ b/README.md
@@ -67,13 +67,8 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 const speech = require('@google-cloud/speech');
 const fs = require('fs');
 
-// Your Google Cloud Platform project ID
-const projectId = 'your-project-id';
-
 // Creates a client
-const client = new speech.SpeechClient({
-  projectId: projectId,
-});
+const client = new speech.SpeechClient();
 
 // The name of the audio file to transcribe
 const fileName = './resources/audio.raw';

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "Jerjou <jerjou@users.noreply.github.com>",
     "Jun Mukai <mukai@google.com>",
     "Luke Sneeringer <lukesneeringer@google.com>",
+    "Philippe Sultan <philippe.sultan@gmail.com>",
     "Pierre Fritsch <PierreFritsch@users.noreply.github.com>",
     "Puneith Kaul <puneith@google.com>",
     "Rebecca Taylor <remilytaylor@gmail.com>",

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -20,13 +20,8 @@
 const speech = require('@google-cloud/speech');
 const fs = require('fs');
 
-// Your Google Cloud Platform project ID
-const projectId = 'your-project-id';
-
 // Creates a client
-const client = new speech.SpeechClient({
-  projectId: projectId,
-});
+const client = new speech.SpeechClient();
 
 // The name of the audio file to transcribe
 const fileName = './resources/audio.raw';


### PR DESCRIPTION
Fixes #46 

These changes simplify the documentation by removing the `projectId` argument in the various instantiations of `SpeechClient`.