### PR TITLE
release 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/speech",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/speech",
   "description": "Cloud Speech Client Library for Node.js",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -159,7 +159,7 @@
       }
     },
     "@google-cloud/speech": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "requires": {
         "extend": "3.0.1",
         "google-gax": "0.16.0",

--- a/samples/package.json
+++ b/samples/package.json
@@ -12,7 +12,7 @@
     "test": "repo-tools test run --cmd ava -- -T 20s --verbose system-test/*.test.js"
   },
   "dependencies": {
-    "@google-cloud/speech": "1.2.0",
+    "@google-cloud/speech": "1.3.0",
     "@google-cloud/storage": "1.4.0",
     "node-record-lpcm16": "0.3.0",
     "yargs": "10.0.3"


### PR DESCRIPTION
@stephenplusplus, @callmehiphop: it would be great to have #47 included in this release, hope it can get approved soon. Let's wait for that PR before merging this one.

---

## Features

In this minor release we updated some protos used by `v1p1beta1` endpoint (added optional `metadata` field to `RecognitionConfig` message). There is no need to change any existing code. Also, `v1` endpoint is still default. If you want to try using the new `v1p1beta1` endpoint, you need to request it in your code:
```js
const speech = require('@google-cloud/nodejs-speech').v1p1beta1;
```

## Fixes

- (#47) Remove projectId argument in samples
---

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
