### PR TITLE
updating GAPIC v1p1beta1 code

### DIFF
--- a/protos/google/cloud/speech/v1p1beta1/cloud_speech.proto
+++ b/protos/google/cloud/speech/v1p1beta1/cloud_speech.proto
@@ -242,6 +242,15 @@ message RecognitionConfig {
   // `false`.
   bool enable_word_time_offsets = 8;
 
+  // *Optional* If 'true', adds punctuation to recognition result hypotheses.
+  // This feature is only available in select languages. Setting this for
+  // requests in other languages has no effect at all.
+  // The default 'false' value does not add punctuation to result hypotheses.
+  // NOTE: "This is currently offered as an experimental service, complimentary
+  // to all users. In the future this may be exclusively available as a
+  // premium feature."
+  bool enable_automatic_punctuation = 11;
+
   // *Optional* Metadata regarding this request.
   RecognitionMetadata metadata = 9;
 

--- a/src/v1p1beta1/doc/google/cloud/speech/v1p1beta1/doc_cloud_speech.js
+++ b/src/v1p1beta1/doc/google/cloud/speech/v1p1beta1/doc_cloud_speech.js
@@ -181,6 +181,15 @@ var StreamingRecognitionConfig = {
  *   `false`, no word-level time offset information is returned. The default is
  *   `false`.
  *
+ * @property {boolean} enableAutomaticPunctuation
+ *   *Optional* If 'true', adds punctuation to recognition result hypotheses.
+ *   This feature is only available in select languages. Setting this for
+ *   requests in other languages has no effect at all.
+ *   The default 'false' value does not add punctuation to result hypotheses.
+ *   NOTE: "This is currently offered as an experimental service, complimentary
+ *   to all users. In the future this may be exclusively available as a
+ *   premium feature."
+ *
  * @property {Object} metadata
  *   *Optional* Metadata regarding this request.
  *


### PR DESCRIPTION
One more small update to protos. Will require semver minor though.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
