### PR TITLE
bump version to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/speech",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -310,7 +310,8 @@
           "dependencies": {
             "align-text": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
               "dev": true,
               "requires": {
                 "kind-of": "^3.0.2",
@@ -320,22 +321,26 @@
             },
             "amdefine": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+              "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
               "dev": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "ansi-styles": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
               "dev": true
             },
             "append-transform": {
               "version": "0.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+              "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
               "dev": true,
               "requires": {
                 "default-require-extensions": "^1.0.0"
@@ -343,12 +348,14 @@
             },
             "archy": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
               "dev": true
             },
             "arr-diff": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+              "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
               "dev": true,
               "requires": {
                 "arr-flatten": "^1.0.1"
@@ -356,27 +363,32 @@
             },
             "arr-flatten": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+              "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
               "dev": true
             },
             "array-unique": {
               "version": "0.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+              "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
               "dev": true
             },
             "arrify": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+              "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
               "dev": true
             },
             "async": {
               "version": "1.5.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
               "dev": true
             },
             "babel-code-frame": {
               "version": "6.26.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+              "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
               "dev": true,
               "requires": {
                 "chalk": "^1.1.3",
@@ -386,7 +398,8 @@
             },
             "babel-generator": {
               "version": "6.26.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+              "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
               "dev": true,
               "requires": {
                 "babel-messages": "^6.23.0",
@@ -401,7 +414,8 @@
             },
             "babel-messages": {
               "version": "6.23.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+              "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
               "dev": true,
               "requires": {
                 "babel-runtime": "^6.22.0"
@@ -409,7 +423,8 @@
             },
             "babel-runtime": {
               "version": "6.26.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+              "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
               "dev": true,
               "requires": {
                 "core-js": "^2.4.0",
@@ -418,7 +433,8 @@
             },
             "babel-template": {
               "version": "6.26.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+              "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
               "dev": true,
               "requires": {
                 "babel-runtime": "^6.26.0",
@@ -430,7 +446,8 @@
             },
             "babel-traverse": {
               "version": "6.26.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+              "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
               "dev": true,
               "requires": {
                 "babel-code-frame": "^6.26.0",
@@ -446,7 +463,8 @@
             },
             "babel-types": {
               "version": "6.26.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+              "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
               "dev": true,
               "requires": {
                 "babel-runtime": "^6.26.0",
@@ -457,17 +475,20 @@
             },
             "babylon": {
               "version": "6.18.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+              "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
               "dev": true
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true
             },
             "brace-expansion": {
               "version": "1.1.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+              "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
               "dev": true,
               "requires": {
                 "balanced-match": "^1.0.0",
@@ -476,7 +497,8 @@
             },
             "braces": {
               "version": "1.8.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+              "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
               "dev": true,
               "requires": {
                 "expand-range": "^1.8.1",
@@ -486,12 +508,14 @@
             },
             "builtin-modules": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
               "dev": true
             },
             "caching-transform": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+              "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
               "dev": true,
               "requires": {
                 "md5-hex": "^1.2.0",
@@ -501,13 +525,15 @@
             },
             "camelcase": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
               "dev": true,
               "optional": true
             },
             "center-align": {
               "version": "0.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+              "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -517,7 +543,8 @@
             },
             "chalk": {
               "version": "1.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
                 "ansi-styles": "^2.2.1",
@@ -529,7 +556,8 @@
             },
             "cliui": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -540,7 +568,8 @@
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
                   "dev": true,
                   "optional": true
                 }
@@ -548,32 +577,38 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true
             },
             "commondir": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+              "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
               "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true
             },
             "convert-source-map": {
               "version": "1.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+              "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
               "dev": true
             },
             "core-js": {
               "version": "2.5.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+              "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
               "dev": true
             },
             "cross-spawn": {
               "version": "4.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+              "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
               "dev": true,
               "requires": {
                 "lru-cache": "^4.0.1",
@@ -582,7 +617,8 @@
             },
             "debug": {
               "version": "2.6.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
               "requires": {
                 "ms": "2.0.0"
@@ -590,17 +626,20 @@
             },
             "debug-log": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+              "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
               "dev": true
             },
             "decamelize": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
               "dev": true
             },
             "default-require-extensions": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+              "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
               "dev": true,
               "requires": {
                 "strip-bom": "^2.0.0"
@@ -608,7 +647,8 @@
             },
             "detect-indent": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+              "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
               "dev": true,
               "requires": {
                 "repeating": "^2.0.0"
@@ -616,7 +656,8 @@
             },
             "error-ex": {
               "version": "1.3.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+              "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
               "dev": true,
               "requires": {
                 "is-arrayish": "^0.2.1"
@@ -624,17 +665,20 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
               "dev": true
             },
             "esutils": {
               "version": "2.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
               "dev": true
             },
             "execa": {
               "version": "0.7.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+              "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
               "dev": true,
               "requires": {
                 "cross-spawn": "^5.0.1",
@@ -648,7 +692,8 @@
               "dependencies": {
                 "cross-spawn": {
                   "version": "5.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                  "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                   "dev": true,
                   "requires": {
                     "lru-cache": "^4.0.1",
@@ -660,7 +705,8 @@
             },
             "expand-brackets": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+              "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
               "dev": true,
               "requires": {
                 "is-posix-bracket": "^0.1.0"
@@ -668,7 +714,8 @@
             },
             "expand-range": {
               "version": "1.8.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+              "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
               "dev": true,
               "requires": {
                 "fill-range": "^2.1.0"
@@ -676,7 +723,8 @@
             },
             "extglob": {
               "version": "0.3.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+              "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
               "dev": true,
               "requires": {
                 "is-extglob": "^1.0.0"
@@ -684,12 +732,14 @@
             },
             "filename-regex": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+              "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
               "dev": true
             },
             "fill-range": {
               "version": "2.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+              "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
               "dev": true,
               "requires": {
                 "is-number": "^2.1.0",
@@ -701,7 +751,8 @@
             },
             "find-cache-dir": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+              "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
               "dev": true,
               "requires": {
                 "commondir": "^1.0.1",
@@ -711,7 +762,8 @@
             },
             "find-up": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
               "dev": true,
               "requires": {
                 "locate-path": "^2.0.0"
@@ -719,12 +771,14 @@
             },
             "for-in": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+              "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
               "dev": true
             },
             "for-own": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+              "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
               "dev": true,
               "requires": {
                 "for-in": "^1.0.1"
@@ -732,7 +786,8 @@
             },
             "foreground-child": {
               "version": "1.5.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+              "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
               "dev": true,
               "requires": {
                 "cross-spawn": "^4",
@@ -741,22 +796,26 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true
             },
             "get-caller-file": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+              "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
               "dev": true
             },
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             },
             "glob": {
               "version": "7.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -769,7 +828,8 @@
             },
             "glob-base": {
               "version": "0.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+              "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
               "dev": true,
               "requires": {
                 "glob-parent": "^2.0.0",
@@ -778,7 +838,8 @@
             },
             "glob-parent": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+              "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
               "dev": true,
               "requires": {
                 "is-glob": "^2.0.0"
@@ -786,17 +847,20 @@
             },
             "globals": {
               "version": "9.18.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+              "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
               "dev": true
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
               "dev": true
             },
             "handlebars": {
               "version": "4.0.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+              "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
               "dev": true,
               "requires": {
                 "async": "^1.4.0",
@@ -807,7 +871,8 @@
               "dependencies": {
                 "source-map": {
                   "version": "0.4.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                   "dev": true,
                   "requires": {
                     "amdefine": ">=0.0.4"
@@ -817,7 +882,8 @@
             },
             "has-ansi": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -825,22 +891,26 @@
             },
             "has-flag": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
               "dev": true
             },
             "hosted-git-info": {
               "version": "2.5.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+              "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
               "dev": true
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
               "dev": true
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "requires": {
                 "once": "^1.3.0",
@@ -849,12 +919,14 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             },
             "invariant": {
               "version": "2.2.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+              "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
               "dev": true,
               "requires": {
                 "loose-envify": "^1.0.0"
@@ -862,22 +934,26 @@
             },
             "invert-kv": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+              "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
               "dev": true
             },
             "is-arrayish": {
               "version": "0.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+              "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
               "dev": true
             },
             "is-buffer": {
               "version": "1.1.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
               "dev": true
             },
             "is-builtin-module": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
               "dev": true,
               "requires": {
                 "builtin-modules": "^1.0.0"
@@ -885,12 +961,14 @@
             },
             "is-dotfile": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+              "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
               "dev": true
             },
             "is-equal-shallow": {
               "version": "0.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+              "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
               "dev": true,
               "requires": {
                 "is-primitive": "^2.0.0"
@@ -898,17 +976,20 @@
             },
             "is-extendable": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
               "dev": true
             },
             "is-extglob": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
               "dev": true
             },
             "is-finite": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+              "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
               "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -916,7 +997,8 @@
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -924,7 +1006,8 @@
             },
             "is-glob": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
                 "is-extglob": "^1.0.0"
@@ -932,7 +1015,8 @@
             },
             "is-number": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+              "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
               "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
@@ -940,37 +1024,44 @@
             },
             "is-posix-bracket": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+              "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
               "dev": true
             },
             "is-primitive": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+              "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
               "dev": true
             },
             "is-stream": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
               "dev": true
             },
             "is-utf8": {
               "version": "0.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
               "dev": true
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
             },
             "isexe": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
               "dev": true
             },
             "isobject": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
                 "isarray": "1.0.0"
@@ -978,12 +1069,14 @@
             },
             "istanbul-lib-coverage": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+              "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
               "dev": true
             },
             "istanbul-lib-hook": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+              "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
               "dev": true,
               "requires": {
                 "append-transform": "^0.4.0"
@@ -991,7 +1084,8 @@
             },
             "istanbul-lib-instrument": {
               "version": "1.9.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
+              "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
               "dev": true,
               "requires": {
                 "babel-generator": "^6.18.0",
@@ -1005,7 +1099,8 @@
             },
             "istanbul-lib-report": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
+              "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
               "dev": true,
               "requires": {
                 "istanbul-lib-coverage": "^1.1.1",
@@ -1016,7 +1111,8 @@
               "dependencies": {
                 "supports-color": {
                   "version": "3.2.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                  "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                   "dev": true,
                   "requires": {
                     "has-flag": "^1.0.0"
@@ -1026,7 +1122,8 @@
             },
             "istanbul-lib-source-maps": {
               "version": "1.2.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
+              "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
               "dev": true,
               "requires": {
                 "debug": "^3.1.0",
@@ -1038,7 +1135,8 @@
               "dependencies": {
                 "debug": {
                   "version": "3.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                  "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                   "dev": true,
                   "requires": {
                     "ms": "2.0.0"
@@ -1048,7 +1146,8 @@
             },
             "istanbul-reports": {
               "version": "1.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
+              "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
               "dev": true,
               "requires": {
                 "handlebars": "^4.0.3"
@@ -1056,17 +1155,20 @@
             },
             "js-tokens": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+              "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
               "dev": true
             },
             "jsesc": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+              "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
               "dev": true
             },
             "kind-of": {
               "version": "3.2.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -1074,13 +1176,15 @@
             },
             "lazy-cache": {
               "version": "1.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
               "dev": true,
               "optional": true
             },
             "lcid": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+              "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
               "dev": true,
               "requires": {
                 "invert-kv": "^1.0.0"
@@ -1088,7 +1192,8 @@
             },
             "load-json-file": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -1100,7 +1205,8 @@
             },
             "locate-path": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+              "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
               "dev": true,
               "requires": {
                 "p-locate": "^2.0.0",
@@ -1109,24 +1215,28 @@
               "dependencies": {
                 "path-exists": {
                   "version": "3.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                  "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                   "dev": true
                 }
               }
             },
             "lodash": {
               "version": "4.17.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
               "dev": true
             },
             "longest": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
               "dev": true
             },
             "loose-envify": {
               "version": "1.3.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+              "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
               "dev": true,
               "requires": {
                 "js-tokens": "^3.0.0"
@@ -1134,7 +1244,8 @@
             },
             "lru-cache": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+              "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
               "dev": true,
               "requires": {
                 "pseudomap": "^1.0.2",
@@ -1143,7 +1254,8 @@
             },
             "md5-hex": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+              "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
               "dev": true,
               "requires": {
                 "md5-o-matic": "^0.1.1"
@@ -1151,12 +1263,14 @@
             },
             "md5-o-matic": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+              "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
               "dev": true
             },
             "mem": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+              "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
               "dev": true,
               "requires": {
                 "mimic-fn": "^1.0.0"
@@ -1164,7 +1278,8 @@
             },
             "merge-source-map": {
               "version": "1.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+              "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
               "dev": true,
               "requires": {
                 "source-map": "^0.5.6"
@@ -1172,7 +1287,8 @@
             },
             "micromatch": {
               "version": "2.3.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+              "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
               "dev": true,
               "requires": {
                 "arr-diff": "^2.0.0",
@@ -1192,12 +1308,14 @@
             },
             "mimic-fn": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+              "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
               "dev": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
@@ -1205,12 +1323,14 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -1218,12 +1338,14 @@
             },
             "ms": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true
             },
             "normalize-package-data": {
               "version": "2.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+              "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
               "dev": true,
               "requires": {
                 "hosted-git-info": "^2.1.4",
@@ -1234,7 +1356,8 @@
             },
             "normalize-path": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
               "dev": true,
               "requires": {
                 "remove-trailing-separator": "^1.0.1"
@@ -1242,7 +1365,8 @@
             },
             "npm-run-path": {
               "version": "2.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+              "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
               "dev": true,
               "requires": {
                 "path-key": "^2.0.0"
@@ -1250,17 +1374,20 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true
             },
             "object.omit": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+              "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
               "dev": true,
               "requires": {
                 "for-own": "^0.1.4",
@@ -1269,7 +1396,8 @@
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
                 "wrappy": "1"
@@ -1277,7 +1405,8 @@
             },
             "optimist": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
               "dev": true,
               "requires": {
                 "minimist": "~0.0.1",
@@ -1286,12 +1415,14 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true
             },
             "os-locale": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+              "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
               "dev": true,
               "requires": {
                 "execa": "^0.7.0",
@@ -1301,17 +1432,20 @@
             },
             "p-finally": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+              "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
               "dev": true
             },
             "p-limit": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+              "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
               "dev": true
             },
             "p-locate": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+              "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
               "dev": true,
               "requires": {
                 "p-limit": "^1.1.0"
@@ -1319,7 +1453,8 @@
             },
             "parse-glob": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+              "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
               "dev": true,
               "requires": {
                 "glob-base": "^0.3.0",
@@ -1330,7 +1465,8 @@
             },
             "parse-json": {
               "version": "2.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
               "dev": true,
               "requires": {
                 "error-ex": "^1.2.0"
@@ -1338,7 +1474,8 @@
             },
             "path-exists": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
               "dev": true,
               "requires": {
                 "pinkie-promise": "^2.0.0"
@@ -1346,22 +1483,26 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true
             },
             "path-key": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
               "dev": true
             },
             "path-parse": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+              "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
               "dev": true
             },
             "path-type": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -1371,17 +1512,20 @@
             },
             "pify": {
               "version": "2.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             },
             "pinkie": {
               "version": "2.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
               "dev": true
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
               "dev": true,
               "requires": {
                 "pinkie": "^2.0.0"
@@ -1389,7 +1533,8 @@
             },
             "pkg-dir": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+              "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
               "dev": true,
               "requires": {
                 "find-up": "^1.0.0"
@@ -1397,7 +1542,8 @@
               "dependencies": {
                 "find-up": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                  "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                   "dev": true,
                   "requires": {
                     "path-exists": "^2.0.0",
@@ -1408,17 +1554,20 @@
             },
             "preserve": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+              "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
               "dev": true
             },
             "pseudomap": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
               "dev": true
             },
             "randomatic": {
               "version": "1.1.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+              "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
               "dev": true,
               "requires": {
                 "is-number": "^3.0.0",
@@ -1427,7 +1576,8 @@
               "dependencies": {
                 "is-number": {
                   "version": "3.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                  "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                   "dev": true,
                   "requires": {
                     "kind-of": "^3.0.2"
@@ -1435,7 +1585,8 @@
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
                         "is-buffer": "^1.1.5"
@@ -1445,7 +1596,8 @@
                 },
                 "kind-of": {
                   "version": "4.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                  "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                   "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
@@ -1455,7 +1607,8 @@
             },
             "read-pkg": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+              "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
               "dev": true,
               "requires": {
                 "load-json-file": "^1.0.0",
@@ -1465,7 +1618,8 @@
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
               "dev": true,
               "requires": {
                 "find-up": "^1.0.0",
@@ -1474,7 +1628,8 @@
               "dependencies": {
                 "find-up": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                  "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                   "dev": true,
                   "requires": {
                     "path-exists": "^2.0.0",
@@ -1485,12 +1640,14 @@
             },
             "regenerator-runtime": {
               "version": "0.11.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+              "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
               "dev": true
             },
             "regex-cache": {
               "version": "0.4.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+              "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
               "dev": true,
               "requires": {
                 "is-equal-shallow": "^0.1.3"
@@ -1498,22 +1655,26 @@
             },
             "remove-trailing-separator": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+              "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
               "dev": true
             },
             "repeat-element": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+              "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
               "dev": true
             },
             "repeat-string": {
               "version": "1.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+              "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
               "dev": true
             },
             "repeating": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+              "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
               "dev": true,
               "requires": {
                 "is-finite": "^1.0.0"
@@ -1521,22 +1682,26 @@
             },
             "require-directory": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
               "dev": true
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
               "dev": true
             },
             "resolve-from": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+              "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
               "dev": true
             },
             "right-align": {
               "version": "0.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+              "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -1545,7 +1710,8 @@
             },
             "rimraf": {
               "version": "2.6.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+              "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
               "dev": true,
               "requires": {
                 "glob": "^7.0.5"
@@ -1553,17 +1719,20 @@
             },
             "semver": {
               "version": "5.4.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
               "dev": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true
             },
             "shebang-command": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
               "dev": true,
               "requires": {
                 "shebang-regex": "^1.0.0"
@@ -1571,27 +1740,32 @@
             },
             "shebang-regex": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
               "dev": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true
             },
             "slide": {
               "version": "1.1.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
               "dev": true
             },
             "source-map": {
               "version": "0.5.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
               "dev": true
             },
             "spawn-wrap": {
               "version": "1.4.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+              "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
               "dev": true,
               "requires": {
                 "foreground-child": "^1.5.6",
@@ -1604,7 +1778,8 @@
             },
             "spdx-correct": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
               "dev": true,
               "requires": {
                 "spdx-license-ids": "^1.0.2"
@@ -1612,17 +1787,20 @@
             },
             "spdx-expression-parse": {
               "version": "1.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
               "dev": true
             },
             "spdx-license-ids": {
               "version": "1.2.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+              "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
               "dev": true
             },
             "string-width": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
@@ -1631,17 +1809,20 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "3.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                   "dev": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                   "dev": true
                 },
                 "strip-ansi": {
                   "version": "4.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "^3.0.0"
@@ -1651,7 +1832,8 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -1659,7 +1841,8 @@
             },
             "strip-bom": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
               "dev": true,
               "requires": {
                 "is-utf8": "^0.2.0"
@@ -1667,17 +1850,20 @@
             },
             "strip-eof": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
               "dev": true
             },
             "supports-color": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
               "dev": true
             },
             "test-exclude": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+              "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
               "dev": true,
               "requires": {
                 "arrify": "^1.0.1",
@@ -1689,17 +1875,20 @@
             },
             "to-fast-properties": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+              "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
               "dev": true
             },
             "trim-right": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+              "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
               "dev": true
             },
             "uglify-js": {
               "version": "2.8.29",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+              "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -1710,7 +1899,8 @@
               "dependencies": {
                 "yargs": {
                   "version": "3.10.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -1724,13 +1914,15 @@
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
               "dev": true,
               "optional": true
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
               "dev": true,
               "requires": {
                 "spdx-correct": "~1.0.0",
@@ -1739,7 +1931,8 @@
             },
             "which": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+              "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
               "dev": true,
               "requires": {
                 "isexe": "^2.0.0"
@@ -1747,23 +1940,27 @@
             },
             "which-module": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
               "dev": true
             },
             "window-size": {
               "version": "0.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+              "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
               "dev": true,
               "optional": true
             },
             "wordwrap": {
               "version": "0.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
               "dev": true
             },
             "wrap-ansi": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+              "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
               "dev": true,
               "requires": {
                 "string-width": "^1.0.1",
@@ -1772,7 +1969,8 @@
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
@@ -1784,12 +1982,14 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true
             },
             "write-file-atomic": {
               "version": "1.3.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+              "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.11",
@@ -1799,17 +1999,20 @@
             },
             "y18n": {
               "version": "3.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "dev": true
             },
             "yallist": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
               "dev": true
             },
             "yargs": {
               "version": "10.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+              "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
               "dev": true,
               "requires": {
                 "cliui": "^3.2.0",
@@ -1828,7 +2031,8 @@
               "dependencies": {
                 "cliui": {
                   "version": "3.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                  "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                   "dev": true,
                   "requires": {
                     "string-width": "^1.0.1",
@@ -1838,7 +2042,8 @@
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "requires": {
                         "code-point-at": "^1.0.0",
@@ -1852,7 +2057,8 @@
             },
             "yargs-parser": {
               "version": "8.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+              "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
               "dev": true,
               "requires": {
                 "camelcase": "^4.1.0"
@@ -1860,7 +2066,8 @@
               "dependencies": {
                 "camelcase": {
                   "version": "4.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                  "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                   "dev": true
                 }
               }
@@ -5162,24 +5369,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5189,12 +5400,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -5203,34 +5416,40 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5239,25 +5458,29 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5266,13 +5489,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5288,7 +5513,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5302,13 +5528,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5317,7 +5545,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5326,7 +5555,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5336,18 +5566,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -5355,13 +5588,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -5369,12 +5604,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1",
@@ -5383,7 +5620,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5392,7 +5630,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -5400,13 +5639,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5417,7 +5658,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5435,7 +5677,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5445,13 +5688,15 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5461,7 +5706,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5473,18 +5719,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -5492,19 +5741,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5514,19 +5766,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5538,7 +5793,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -5546,7 +5802,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5561,7 +5818,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5570,42 +5828,49 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -5615,7 +5880,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5624,7 +5890,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5632,13 +5899,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5653,13 +5922,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5668,12 +5939,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
       }
@@ -5964,19 +6237,23 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -5984,11 +6261,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5996,57 +6275,69 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "requires": {
             "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -6060,7 +6351,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -6072,25 +6364,29 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "requires": {
             "minimatch": "^3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -6098,37 +6394,44 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "minipass": {
           "version": "2.3.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
+          "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6136,31 +6439,36 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "requires": {
             "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
           },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             }
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "needle": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz",
+          "integrity": "sha512-t/ZswCM9JTWjAdXS9VpvqhI2Ct2sL2MdY4fUXqGJaGBk13ge99ObqRksRTbBE56K+wxUXwwfZYOuZHifFW9q+Q==",
           "requires": {
             "debug": "^2.1.2",
             "iconv-lite": "^0.4.4",
@@ -6169,7 +6477,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.2.tgz",
+          "integrity": "sha512-16lql9QTqs6KsB9fl3neWyZm02KxIKdI9FlJjrB0y7eMTP5Nyz+xalwPbOlw3iw7EejllJPmlJSnY711PLD1ug==",
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -6185,7 +6494,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -6193,11 +6503,13 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow=="
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -6205,7 +6517,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -6215,30 +6528,36 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -6246,11 +6565,13 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "protobufjs": {
           "version": "5.0.3",
@@ -6265,7 +6586,8 @@
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -6275,7 +6597,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -6288,38 +6611,46 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
             "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6328,25 +6659,29 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "tar": {
           "version": "4.4.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.4.tgz",
+          "integrity": "sha512-mq9ixIYfNF9SK0IS/h2HKMu8Q2iaCuhDDsZhdEag/FHv8fOaYld4vN7ouMgcSSt5WKZzPs8atclTcJm36OTh4w==",
           "requires": {
             "chownr": "^1.0.1",
             "fs-minipass": "^1.2.5",
@@ -6359,22 +6694,26 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },
@@ -8119,7 +8458,8 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2",
@@ -8129,17 +8469,20 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "dev": true,
           "requires": {
             "default-require-extensions": "^1.0.0"
@@ -8147,57 +8490,68 @@
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arr-diff": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+          "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
           "dev": true
         },
         "arr-union": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "atob": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+          "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "base": {
           "version": "0.11.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+          "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
           "dev": true,
           "requires": {
             "cache-base": "^1.0.1",
@@ -8211,7 +8565,8 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -8219,7 +8574,8 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -8227,7 +8583,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -8235,7 +8592,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -8245,14 +8603,16 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
               "dev": true
             }
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -8261,7 +8621,8 @@
         },
         "braces": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -8278,7 +8639,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -8288,12 +8650,14 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "cache-base": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+          "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
           "dev": true,
           "requires": {
             "collection-visit": "^1.0.0",
@@ -8309,7 +8673,8 @@
         },
         "caching-transform": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "dev": true,
           "requires": {
             "md5-hex": "^1.2.0",
@@ -8319,13 +8684,15 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -8335,7 +8702,8 @@
         },
         "class-utils": {
           "version": "0.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+          "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -8346,7 +8714,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -8356,7 +8725,8 @@
         },
         "cliui": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -8367,7 +8737,8 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
               "dev": true,
               "optional": true
             }
@@ -8375,12 +8746,14 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "collection-visit": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
           "dev": true,
           "requires": {
             "map-visit": "^1.0.0",
@@ -8389,32 +8762,38 @@
         },
         "commondir": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "component-emitter": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
           "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -8423,7 +8802,8 @@
         },
         "debug": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -8431,22 +8811,26 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "dev": true,
           "requires": {
             "strip-bom": "^2.0.0"
@@ -8454,7 +8838,8 @@
         },
         "define-property": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+          "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.2",
@@ -8463,7 +8848,8 @@
           "dependencies": {
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -8471,7 +8857,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -8479,7 +8866,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -8489,14 +8877,16 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
               "dev": true
             }
           }
         },
         "error-ex": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
@@ -8504,7 +8894,8 @@
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -8518,7 +8909,8 @@
           "dependencies": {
             "cross-spawn": {
               "version": "5.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
               "dev": true,
               "requires": {
                 "lru-cache": "^4.0.1",
@@ -8530,7 +8922,8 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
             "debug": "^2.3.3",
@@ -8544,7 +8937,8 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
               "dev": true,
               "requires": {
                 "ms": "2.0.0"
@@ -8552,7 +8946,8 @@
             },
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -8560,7 +8955,8 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -8570,7 +8966,8 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
             "assign-symbols": "^1.0.0",
@@ -8579,7 +8976,8 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
               "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
@@ -8589,7 +8987,8 @@
         },
         "extglob": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
           "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
@@ -8604,7 +9003,8 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -8612,7 +9012,8 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -8620,7 +9021,8 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -8628,7 +9030,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -8636,7 +9039,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -8646,14 +9050,16 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
               "dev": true
             }
           }
         },
         "fill-range": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -8664,7 +9070,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -8674,7 +9081,8 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
@@ -8684,7 +9092,8 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -8692,12 +9101,14 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         },
         "foreground-child": {
           "version": "1.5.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
             "cross-spawn": "^4",
@@ -8706,7 +9117,8 @@
         },
         "fragment-cache": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
           "dev": true,
           "requires": {
             "map-cache": "^0.2.2"
@@ -8714,27 +9126,32 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "get-value": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -8747,12 +9164,14 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
           "dev": true,
           "requires": {
             "async": "^1.4.0",
@@ -8763,7 +9182,8 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
                 "amdefine": ">=0.0.4"
@@ -8773,7 +9193,8 @@
         },
         "has-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "dev": true,
           "requires": {
             "get-value": "^2.0.6",
@@ -8783,7 +9204,8 @@
         },
         "has-values": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -8792,7 +9214,8 @@
           "dependencies": {
             "kind-of": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -8802,17 +9225,20 @@
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+          "integrity": "sha1-IyNbKasjDFdqqw1PE/wEawsDgiI=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -8821,17 +9247,20 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -8839,17 +9268,20 @@
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
             "builtin-modules": "^1.0.0"
@@ -8857,7 +9289,8 @@
         },
         "is-data-descriptor": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -8865,7 +9298,8 @@
         },
         "is-descriptor": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
@@ -8875,24 +9309,28 @@
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
               "dev": true
             }
           }
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-number": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -8900,7 +9338,8 @@
         },
         "is-odd": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+          "integrity": "sha1-dkZiRnH9fqVYzNmieVGC8pWPGyQ=",
           "dev": true,
           "requires": {
             "is-number": "^4.0.0"
@@ -8908,14 +9347,16 @@
           "dependencies": {
             "is-number": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+              "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
               "dev": true
             }
           }
         },
         "is-plain-object": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
           "dev": true,
           "requires": {
             "isobject": "^3.0.1"
@@ -8923,42 +9364,50 @@
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
           "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+          "integrity": "sha1-99jy5CuX43/nlhFMsPnWi146Q0E=",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+          "integrity": "sha1-hTjZcDcss3FtU+VVI91UtVeo2Js=",
           "dev": true,
           "requires": {
             "append-transform": "^0.4.0"
@@ -8966,7 +9415,8 @@
         },
         "istanbul-lib-report": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
+          "integrity": "sha1-LfEhiMD6d5kMDSF20tC6M5QYglk=",
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "^1.1.2",
@@ -8977,12 +9427,14 @@
           "dependencies": {
             "has-flag": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
               "dev": true
             },
             "supports-color": {
               "version": "3.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "dev": true,
               "requires": {
                 "has-flag": "^1.0.0"
@@ -8992,7 +9444,8 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
+          "integrity": "sha1-/+a+Tnq4bTYD5CkNVJkLFFBvybE=",
           "dev": true,
           "requires": {
             "debug": "^3.1.0",
@@ -9004,7 +9457,8 @@
         },
         "istanbul-reports": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.4.1.tgz",
+          "integrity": "sha1-Ty6OkoqnoF0dpsQn1AmLJlXsczQ=",
           "dev": true,
           "requires": {
             "handlebars": "^4.0.3"
@@ -9012,7 +9466,8 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -9020,13 +9475,15 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
@@ -9034,7 +9491,8 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -9046,7 +9504,8 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -9055,19 +9514,22 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
               "dev": true
             }
           }
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -9076,12 +9538,14 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
           "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "dev": true,
           "requires": {
             "object-visit": "^1.0.0"
@@ -9089,7 +9553,8 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
             "md5-o-matic": "^0.1.1"
@@ -9097,12 +9562,14 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -9110,7 +9577,8 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+          "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
           "dev": true,
           "requires": {
             "source-map": "^0.6.1"
@@ -9118,14 +9586,16 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
               "dev": true
             }
           }
         },
         "micromatch": {
           "version": "3.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -9145,19 +9615,22 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
               "dev": true
             }
           }
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -9165,12 +9638,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mixin-deep": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+          "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
           "dev": true,
           "requires": {
             "for-in": "^1.0.2",
@@ -9179,7 +9654,8 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
               "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
@@ -9189,7 +9665,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -9197,12 +9674,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "nanomatch": {
           "version": "1.2.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+          "integrity": "sha1-h59xUMstq3pHElkGbBBO7m4Pp8I=",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -9221,14 +9700,16 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
               "dev": true
             }
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -9239,7 +9720,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -9247,17 +9729,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object-copy": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
           "dev": true,
           "requires": {
             "copy-descriptor": "^0.1.0",
@@ -9267,7 +9752,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -9277,7 +9763,8 @@
         },
         "object-visit": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
           "dev": true,
           "requires": {
             "isobject": "^3.0.0"
@@ -9285,7 +9772,8 @@
         },
         "object.pick": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
           "dev": true,
           "requires": {
             "isobject": "^3.0.1"
@@ -9293,7 +9781,8 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -9301,7 +9790,8 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
             "minimist": "~0.0.1",
@@ -9310,12 +9800,14 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -9325,12 +9817,14 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+          "integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -9338,7 +9832,8 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -9346,12 +9841,14 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
@@ -9359,12 +9856,14 @@
         },
         "pascalcase": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
           "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -9372,22 +9871,26 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -9397,17 +9900,20 @@
         },
         "pify": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
             "pinkie": "^2.0.0"
@@ -9415,7 +9921,8 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
             "find-up": "^1.0.0"
@@ -9423,7 +9930,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -9434,17 +9942,20 @@
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
             "load-json-file": "^1.0.0",
@@ -9454,7 +9965,8 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
             "find-up": "^1.0.0",
@@ -9463,7 +9975,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -9474,7 +9987,8 @@
         },
         "regex-not": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+          "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
           "dev": true,
           "requires": {
             "extend-shallow": "^3.0.2",
@@ -9483,42 +9997,50 @@
         },
         "repeat-element": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
           "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         },
         "resolve-url": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
           "dev": true
         },
         "ret": {
           "version": "0.1.15",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+          "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -9527,7 +10049,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
           "dev": true,
           "requires": {
             "glob": "^7.0.5"
@@ -9535,7 +10058,8 @@
         },
         "safe-regex": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
           "dev": true,
           "requires": {
             "ret": "~0.1.10"
@@ -9543,17 +10067,20 @@
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "set-value": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+          "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -9564,7 +10091,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -9574,7 +10102,8 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -9582,22 +10111,26 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "snapdragon": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+          "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
           "dev": true,
           "requires": {
             "base": "^0.11.1",
@@ -9612,7 +10145,8 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
               "dev": true,
               "requires": {
                 "ms": "2.0.0"
@@ -9620,7 +10154,8 @@
             },
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -9628,7 +10163,8 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -9638,7 +10174,8 @@
         },
         "snapdragon-node": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+          "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
           "dev": true,
           "requires": {
             "define-property": "^1.0.0",
@@ -9648,7 +10185,8 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -9656,7 +10194,8 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -9664,7 +10203,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -9672,7 +10212,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -9682,14 +10223,16 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
               "dev": true
             }
           }
         },
         "snapdragon-util": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+          "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
           "dev": true,
           "requires": {
             "kind-of": "^3.2.0"
@@ -9697,12 +10240,14 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
         "source-map-resolve": {
           "version": "0.5.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+          "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
           "dev": true,
           "requires": {
             "atob": "^2.1.1",
@@ -9714,12 +10259,14 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+          "integrity": "sha1-z/WOc6giRhe2Vhq9wyWG6gyCJIw=",
           "dev": true,
           "requires": {
             "foreground-child": "^1.5.6",
@@ -9732,7 +10279,8 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+          "integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -9741,12 +10289,14 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+          "integrity": "sha1-LHrmEFbHFKW5ubKyr30xHvXHj+k=",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -9755,12 +10305,14 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+          "integrity": "sha1-enzShHDMbToc/m1miG9rxDDTrIc=",
           "dev": true
         },
         "split-string": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+          "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
           "dev": true,
           "requires": {
             "extend-shallow": "^3.0.0"
@@ -9768,7 +10320,8 @@
         },
         "static-extend": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
           "dev": true,
           "requires": {
             "define-property": "^0.2.5",
@@ -9777,7 +10330,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -9787,7 +10341,8 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -9796,7 +10351,8 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -9804,7 +10360,8 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
             "is-utf8": "^0.2.0"
@@ -9812,12 +10369,14 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "test-exclude": {
           "version": "4.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
+          "integrity": "sha1-36Ii8DSAvKaSB8pyizfXS0X3JPo=",
           "dev": true,
           "requires": {
             "arrify": "^1.0.1",
@@ -9829,7 +10388,8 @@
         },
         "to-object-path": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -9837,7 +10397,8 @@
         },
         "to-regex": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+          "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
           "dev": true,
           "requires": {
             "define-property": "^2.0.2",
@@ -9848,7 +10409,8 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -9857,7 +10419,8 @@
         },
         "uglify-js": {
           "version": "2.8.29",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -9868,7 +10431,8 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9882,13 +10446,15 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "dev": true,
           "optional": true
         },
         "union-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -9899,7 +10465,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -9907,7 +10474,8 @@
             },
             "set-value": {
               "version": "0.4.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
               "dev": true,
               "requires": {
                 "extend-shallow": "^2.0.1",
@@ -9920,7 +10488,8 @@
         },
         "unset-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
           "dev": true,
           "requires": {
             "has-value": "^0.3.1",
@@ -9929,7 +10498,8 @@
           "dependencies": {
             "has-value": {
               "version": "0.3.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
               "dev": true,
               "requires": {
                 "get-value": "^2.0.3",
@@ -9939,7 +10509,8 @@
               "dependencies": {
                 "isobject": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
                   "dev": true,
                   "requires": {
                     "isarray": "1.0.0"
@@ -9949,19 +10520,22 @@
             },
             "has-values": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
               "dev": true
             }
           }
         },
         "urix": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
           "dev": true
         },
         "use": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+          "integrity": "sha1-FHFr8D/f79AwQK71jYtLhfOnxUQ=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.2"
@@ -9969,14 +10543,16 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
               "dev": true
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+          "integrity": "sha1-gWQ7y+8b3+zUYjeT3EZIlIupgzg=",
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -9985,7 +10561,8 @@
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -9993,23 +10570,27 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -10018,12 +10599,14 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -10031,7 +10614,8 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -10041,7 +10625,8 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -10051,12 +10636,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -10066,17 +10653,20 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "11.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "integrity": "sha1-kLhpk07W6HERXqL/WLA/RyTtLXc=",
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
@@ -10095,12 +10685,14 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             },
             "cliui": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+              "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
               "dev": true,
               "requires": {
                 "string-width": "^2.1.1",
@@ -10110,7 +10702,8 @@
             },
             "yargs-parser": {
               "version": "9.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
               "dev": true,
               "requires": {
                 "camelcase": "^4.1.0"
@@ -10120,7 +10713,8 @@
         },
         "yargs-parser": {
           "version": "8.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+          "integrity": "sha1-8TdqM7Ziml0GN4KUTacyYx6WaVA=",
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -10128,7 +10722,8 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             }
           }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/speech",
   "description": "Cloud Speech Client Library for Node.js",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -150,30 +150,11 @@
             "wrap-ansi": "^2.0.0"
           }
         },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
         },
         "lodash": {
           "version": "4.17.5",
@@ -191,30 +172,6 @@
             "lcid": "^1.0.0",
             "mem": "^1.1.0"
           }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
         },
         "proxyquire": {
           "version": "1.8.0",
@@ -293,18 +250,10537 @@
       }
     },
     "@google-cloud/speech": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/speech/-/speech-1.5.0.tgz",
-      "integrity": "sha512-mlmG7Yjz9/NLbzBX7P7Jsa24iEYj3JH6/ZZ8HpLUd+t6ipCXgWrmqVfHm8ZoB4biM+WbowMyZXe28huVM14xZA==",
+      "version": "2.0.0",
       "requires": {
-        "extend": "^3.0.0",
-        "google-gax": "^0.16.0",
-        "google-proto-files": "^0.15.0",
-        "lodash.merge": "^4.6.0",
-        "protobufjs": "^6.8.0",
-        "pumpify": "^1.3.5",
-        "stream-events": "^1.0.1",
+        "extend": "^3.0.1",
+        "google-gax": "^0.17.0",
+        "google-proto-files": "^0.16.0",
+        "lodash.merge": "^4.6.1",
+        "protobufjs": "^6.8.6",
+        "pumpify": "^1.5.1",
+        "stream-events": "^1.0.4",
         "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "@ava/babel-plugin-throws-helper": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "@ava/babel-preset-stage-4": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "^6.8.0",
+            "babel-plugin-syntax-trailing-function-commas": "^6.20.0",
+            "babel-plugin-transform-async-to-generator": "^6.16.0",
+            "babel-plugin-transform-es2015-destructuring": "^6.19.0",
+            "babel-plugin-transform-es2015-function-name": "^6.9.0",
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
+            "babel-plugin-transform-es2015-parameters": "^6.21.0",
+            "babel-plugin-transform-es2015-spread": "^6.8.0",
+            "babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
+            "babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
+            "babel-plugin-transform-exponentiation-operator": "^6.8.0",
+            "package-hash": "^1.2.0"
+          },
+          "dependencies": {
+            "md5-hex": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "md5-o-matic": "^0.1.1"
+              }
+            },
+            "package-hash": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "md5-hex": "^1.3.0"
+              }
+            }
+          }
+        },
+        "@ava/babel-preset-transform-test-files": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "@ava/babel-plugin-throws-helper": "^2.0.0",
+            "babel-plugin-espower": "^2.3.2"
+          }
+        },
+        "@ava/write-file-atomic": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
+          }
+        },
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.51",
+          "bundled": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.51"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.51",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.51",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.5",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "2.5.1",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.51",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.51",
+            "@babel/template": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.51",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.51"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.51",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.51"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.51",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.0.0-beta.51",
+          "bundled": true
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.51",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.51",
+            "@babel/parser": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.51",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.51",
+            "@babel/generator": "7.0.0-beta.51",
+            "@babel/helper-function-name": "7.0.0-beta.51",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.51",
+            "@babel/parser": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.17.5"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "globals": {
+              "version": "11.7.0",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.51",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          },
+          "dependencies": {
+            "to-fast-properties": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "@concordance/react": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "^1.0.1"
+          }
+        },
+        "@google-cloud/nodejs-repo-tools": {
+          "version": "https://registry.npmjs.org/@google-cloud/nodejs-repo-tools/-/nodejs-repo-tools-2.3.0.tgz",
+          "bundled": true,
+          "requires": {
+            "ava": "0.25.0",
+            "colors": "1.1.2",
+            "fs-extra": "5.0.0",
+            "got": "8.2.0",
+            "handlebars": "4.0.11",
+            "lodash": "4.17.5",
+            "nyc": "11.4.1",
+            "proxyquire": "1.8.0",
+            "semver": "^5.5.0",
+            "sinon": "4.3.0",
+            "string": "3.3.3",
+            "supertest": "3.0.0",
+            "yargs": "11.0.0",
+            "yargs-parser": "9.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "cliui": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "lodash": {
+              "version": "4.17.5",
+              "bundled": true
+            },
+            "nyc": {
+              "version": "11.4.1",
+              "bundled": true,
+              "requires": {
+                "archy": "^1.0.0",
+                "arrify": "^1.0.1",
+                "caching-transform": "^1.0.0",
+                "convert-source-map": "^1.3.0",
+                "debug-log": "^1.0.1",
+                "default-require-extensions": "^1.0.0",
+                "find-cache-dir": "^0.1.1",
+                "find-up": "^2.1.0",
+                "foreground-child": "^1.5.3",
+                "glob": "^7.0.6",
+                "istanbul-lib-coverage": "^1.1.1",
+                "istanbul-lib-hook": "^1.1.0",
+                "istanbul-lib-instrument": "^1.9.1",
+                "istanbul-lib-report": "^1.1.2",
+                "istanbul-lib-source-maps": "^1.2.2",
+                "istanbul-reports": "^1.1.3",
+                "md5-hex": "^1.2.0",
+                "merge-source-map": "^1.0.2",
+                "micromatch": "^2.3.11",
+                "mkdirp": "^0.5.0",
+                "resolve-from": "^2.0.0",
+                "rimraf": "^2.5.4",
+                "signal-exit": "^3.0.1",
+                "spawn-wrap": "^1.4.2",
+                "test-exclude": "^4.1.1",
+                "yargs": "^10.0.3",
+                "yargs-parser": "^8.0.0"
+              },
+              "dependencies": {
+                "align-text": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^3.0.2",
+                    "longest": "^1.0.1",
+                    "repeat-string": "^1.5.2"
+                  }
+                },
+                "amdefine": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "bundled": true
+                },
+                "append-transform": {
+                  "version": "0.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "default-require-extensions": "^1.0.0"
+                  }
+                },
+                "archy": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "arr-diff": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "arr-flatten": "^1.0.1"
+                  }
+                },
+                "arr-flatten": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "array-unique": {
+                  "version": "0.2.1",
+                  "bundled": true
+                },
+                "arrify": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "async": {
+                  "version": "1.5.2",
+                  "bundled": true
+                },
+                "babel-code-frame": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "^1.1.3",
+                    "esutils": "^2.0.2",
+                    "js-tokens": "^3.0.2"
+                  }
+                },
+                "babel-generator": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-messages": "^6.23.0",
+                    "babel-runtime": "^6.26.0",
+                    "babel-types": "^6.26.0",
+                    "detect-indent": "^4.0.0",
+                    "jsesc": "^1.3.0",
+                    "lodash": "^4.17.4",
+                    "source-map": "^0.5.6",
+                    "trim-right": "^1.0.1"
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.23.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "^6.22.0"
+                  }
+                },
+                "babel-runtime": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "core-js": "^2.4.0",
+                    "regenerator-runtime": "^0.11.0"
+                  }
+                },
+                "babel-template": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "^6.26.0",
+                    "babel-traverse": "^6.26.0",
+                    "babel-types": "^6.26.0",
+                    "babylon": "^6.18.0",
+                    "lodash": "^4.17.4"
+                  }
+                },
+                "babel-traverse": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-code-frame": "^6.26.0",
+                    "babel-messages": "^6.23.0",
+                    "babel-runtime": "^6.26.0",
+                    "babel-types": "^6.26.0",
+                    "babylon": "^6.18.0",
+                    "debug": "^2.6.8",
+                    "globals": "^9.18.0",
+                    "invariant": "^2.2.2",
+                    "lodash": "^4.17.4"
+                  }
+                },
+                "babel-types": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "^6.26.0",
+                    "esutils": "^2.0.2",
+                    "lodash": "^4.17.4",
+                    "to-fast-properties": "^1.0.3"
+                  }
+                },
+                "babylon": {
+                  "version": "6.18.0",
+                  "bundled": true
+                },
+                "balanced-match": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "^1.0.0",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "braces": {
+                  "version": "1.8.5",
+                  "bundled": true,
+                  "requires": {
+                    "expand-range": "^1.8.1",
+                    "preserve": "^0.2.0",
+                    "repeat-element": "^1.1.2"
+                  }
+                },
+                "builtin-modules": {
+                  "version": "1.1.1",
+                  "bundled": true
+                },
+                "caching-transform": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "md5-hex": "^1.2.0",
+                    "mkdirp": "^0.5.1",
+                    "write-file-atomic": "^1.1.4"
+                  }
+                },
+                "camelcase": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "center-align": {
+                  "version": "0.1.3",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "align-text": "^0.1.3",
+                    "lazy-cache": "^1.0.3"
+                  }
+                },
+                "chalk": {
+                  "version": "1.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "^2.2.1",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
+                  }
+                },
+                "cliui": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "center-align": "^0.1.1",
+                    "right-align": "^0.1.1",
+                    "wordwrap": "0.0.2"
+                  },
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "commondir": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "bundled": true
+                },
+                "convert-source-map": {
+                  "version": "1.5.1",
+                  "bundled": true
+                },
+                "core-js": {
+                  "version": "2.5.3",
+                  "bundled": true
+                },
+                "cross-spawn": {
+                  "version": "4.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "lru-cache": "^4.0.1",
+                    "which": "^1.2.9"
+                  }
+                },
+                "debug": {
+                  "version": "2.6.9",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "debug-log": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "default-require-extensions": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "strip-bom": "^2.0.0"
+                  }
+                },
+                "detect-indent": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "repeating": "^2.0.0"
+                  }
+                },
+                "error-ex": {
+                  "version": "1.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-arrayish": "^0.2.1"
+                  }
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "bundled": true
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "bundled": true
+                },
+                "execa": {
+                  "version": "0.7.0",
+                  "bundled": true,
+                  "requires": {
+                    "cross-spawn": "^5.0.1",
+                    "get-stream": "^3.0.0",
+                    "is-stream": "^1.1.0",
+                    "npm-run-path": "^2.0.0",
+                    "p-finally": "^1.0.0",
+                    "signal-exit": "^3.0.0",
+                    "strip-eof": "^1.0.0"
+                  },
+                  "dependencies": {
+                    "cross-spawn": {
+                      "version": "5.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                      }
+                    }
+                  }
+                },
+                "expand-brackets": {
+                  "version": "0.1.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-posix-bracket": "^0.1.0"
+                  }
+                },
+                "expand-range": {
+                  "version": "1.8.2",
+                  "bundled": true,
+                  "requires": {
+                    "fill-range": "^2.1.0"
+                  }
+                },
+                "extglob": {
+                  "version": "0.3.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-extglob": "^1.0.0"
+                  }
+                },
+                "filename-regex": {
+                  "version": "2.0.1",
+                  "bundled": true
+                },
+                "fill-range": {
+                  "version": "2.2.3",
+                  "bundled": true,
+                  "requires": {
+                    "is-number": "^2.1.0",
+                    "isobject": "^2.0.0",
+                    "randomatic": "^1.1.3",
+                    "repeat-element": "^1.1.2",
+                    "repeat-string": "^1.5.2"
+                  }
+                },
+                "find-cache-dir": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "commondir": "^1.0.1",
+                    "mkdirp": "^0.5.1",
+                    "pkg-dir": "^1.0.0"
+                  }
+                },
+                "find-up": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "locate-path": "^2.0.0"
+                  }
+                },
+                "for-in": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "for-own": {
+                  "version": "0.1.5",
+                  "bundled": true,
+                  "requires": {
+                    "for-in": "^1.0.1"
+                  }
+                },
+                "foreground-child": {
+                  "version": "1.5.6",
+                  "bundled": true,
+                  "requires": {
+                    "cross-spawn": "^4",
+                    "signal-exit": "^3.0.0"
+                  }
+                },
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "get-caller-file": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "get-stream": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "glob": {
+                  "version": "7.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.4",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
+                  }
+                },
+                "glob-base": {
+                  "version": "0.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "glob-parent": "^2.0.0",
+                    "is-glob": "^2.0.0"
+                  }
+                },
+                "glob-parent": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-glob": "^2.0.0"
+                  }
+                },
+                "globals": {
+                  "version": "9.18.0",
+                  "bundled": true
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "bundled": true
+                },
+                "handlebars": {
+                  "version": "4.0.11",
+                  "bundled": true,
+                  "requires": {
+                    "async": "^1.4.0",
+                    "optimist": "^0.6.1",
+                    "source-map": "^0.4.4",
+                    "uglify-js": "^2.6"
+                  },
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.4.4",
+                      "bundled": true,
+                      "requires": {
+                        "amdefine": ">=0.0.4"
+                      }
+                    }
+                  }
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^2.0.0"
+                  }
+                },
+                "has-flag": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "hosted-git-info": {
+                  "version": "2.5.0",
+                  "bundled": true
+                },
+                "imurmurhash": {
+                  "version": "0.1.4",
+                  "bundled": true
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "bundled": true,
+                  "requires": {
+                    "once": "^1.3.0",
+                    "wrappy": "1"
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "bundled": true
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "loose-envify": "^1.0.0"
+                  }
+                },
+                "invert-kv": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "is-arrayish": {
+                  "version": "0.2.1",
+                  "bundled": true
+                },
+                "is-buffer": {
+                  "version": "1.1.6",
+                  "bundled": true
+                },
+                "is-builtin-module": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "builtin-modules": "^1.0.0"
+                  }
+                },
+                "is-dotfile": {
+                  "version": "1.0.3",
+                  "bundled": true
+                },
+                "is-equal-shallow": {
+                  "version": "0.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "is-primitive": "^2.0.0"
+                  }
+                },
+                "is-extendable": {
+                  "version": "0.1.1",
+                  "bundled": true
+                },
+                "is-extglob": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "is-finite": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "^1.0.0"
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "^1.0.0"
+                  }
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extglob": "^1.0.0"
+                  }
+                },
+                "is-number": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  }
+                },
+                "is-posix-bracket": {
+                  "version": "0.1.1",
+                  "bundled": true
+                },
+                "is-primitive": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "is-stream": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "is-utf8": {
+                  "version": "0.2.1",
+                  "bundled": true
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "isexe": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                },
+                "istanbul-lib-coverage": {
+                  "version": "1.1.1",
+                  "bundled": true
+                },
+                "istanbul-lib-hook": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "append-transform": "^0.4.0"
+                  }
+                },
+                "istanbul-lib-instrument": {
+                  "version": "1.9.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-generator": "^6.18.0",
+                    "babel-template": "^6.16.0",
+                    "babel-traverse": "^6.18.0",
+                    "babel-types": "^6.18.0",
+                    "babylon": "^6.18.0",
+                    "istanbul-lib-coverage": "^1.1.1",
+                    "semver": "^5.3.0"
+                  }
+                },
+                "istanbul-lib-report": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "istanbul-lib-coverage": "^1.1.1",
+                    "mkdirp": "^0.5.1",
+                    "path-parse": "^1.0.5",
+                    "supports-color": "^3.1.2"
+                  },
+                  "dependencies": {
+                    "supports-color": {
+                      "version": "3.2.3",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "^1.0.0"
+                      }
+                    }
+                  }
+                },
+                "istanbul-lib-source-maps": {
+                  "version": "1.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "debug": "^3.1.0",
+                    "istanbul-lib-coverage": "^1.1.1",
+                    "mkdirp": "^0.5.1",
+                    "rimraf": "^2.6.1",
+                    "source-map": "^0.5.3"
+                  },
+                  "dependencies": {
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "istanbul-reports": {
+                  "version": "1.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "handlebars": "^4.0.3"
+                  }
+                },
+                "js-tokens": {
+                  "version": "3.0.2",
+                  "bundled": true
+                },
+                "jsesc": {
+                  "version": "1.3.0",
+                  "bundled": true
+                },
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                },
+                "lazy-cache": {
+                  "version": "1.0.4",
+                  "bundled": true,
+                  "optional": true
+                },
+                "lcid": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "invert-kv": "^1.0.0"
+                  }
+                },
+                "load-json-file": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "^4.1.2",
+                    "parse-json": "^2.2.0",
+                    "pify": "^2.0.0",
+                    "pinkie-promise": "^2.0.0",
+                    "strip-bom": "^2.0.0"
+                  }
+                },
+                "locate-path": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-locate": "^2.0.0",
+                    "path-exists": "^3.0.0"
+                  },
+                  "dependencies": {
+                    "path-exists": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "bundled": true
+                },
+                "longest": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "loose-envify": {
+                  "version": "1.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "js-tokens": "^3.0.0"
+                  }
+                },
+                "lru-cache": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "pseudomap": "^1.0.2",
+                    "yallist": "^2.1.2"
+                  }
+                },
+                "md5-hex": {
+                  "version": "1.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "md5-o-matic": "^0.1.1"
+                  }
+                },
+                "md5-o-matic": {
+                  "version": "0.1.1",
+                  "bundled": true
+                },
+                "mem": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "mimic-fn": "^1.0.0"
+                  }
+                },
+                "merge-source-map": {
+                  "version": "1.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "source-map": "^0.5.6"
+                  }
+                },
+                "micromatch": {
+                  "version": "2.3.11",
+                  "bundled": true,
+                  "requires": {
+                    "arr-diff": "^2.0.0",
+                    "array-unique": "^0.2.1",
+                    "braces": "^1.8.2",
+                    "expand-brackets": "^0.1.4",
+                    "extglob": "^0.3.1",
+                    "filename-regex": "^2.0.0",
+                    "is-extglob": "^1.0.0",
+                    "is-glob": "^2.0.1",
+                    "kind-of": "^3.0.2",
+                    "normalize-path": "^2.0.1",
+                    "object.omit": "^2.0.0",
+                    "parse-glob": "^3.0.4",
+                    "regex-cache": "^0.4.2"
+                  }
+                },
+                "mimic-fn": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  }
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "normalize-package-data": {
+                  "version": "2.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "hosted-git-info": "^2.1.4",
+                    "is-builtin-module": "^1.0.0",
+                    "semver": "2 || 3 || 4 || 5",
+                    "validate-npm-package-license": "^3.0.1"
+                  }
+                },
+                "normalize-path": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "remove-trailing-separator": "^1.0.1"
+                  }
+                },
+                "npm-run-path": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-key": "^2.0.0"
+                  }
+                },
+                "number-is-nan": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true
+                },
+                "object.omit": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "for-own": "^0.1.4",
+                    "is-extendable": "^0.1.1"
+                  }
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "wrappy": "1"
+                  }
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "bundled": true,
+                  "requires": {
+                    "minimist": "~0.0.1",
+                    "wordwrap": "~0.0.2"
+                  }
+                },
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "os-locale": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "execa": "^0.7.0",
+                    "lcid": "^1.0.0",
+                    "mem": "^1.1.0"
+                  }
+                },
+                "p-finally": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "p-limit": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "p-locate": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-limit": "^1.1.0"
+                  }
+                },
+                "parse-glob": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "glob-base": "^0.3.0",
+                    "is-dotfile": "^1.0.0",
+                    "is-extglob": "^1.0.0",
+                    "is-glob": "^2.0.0"
+                  }
+                },
+                "parse-json": {
+                  "version": "2.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "error-ex": "^1.2.0"
+                  }
+                },
+                "path-exists": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "pinkie-promise": "^2.0.0"
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "path-key": {
+                  "version": "2.0.1",
+                  "bundled": true
+                },
+                "path-parse": {
+                  "version": "1.0.5",
+                  "bundled": true
+                },
+                "path-type": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "^4.1.2",
+                    "pify": "^2.0.0",
+                    "pinkie-promise": "^2.0.0"
+                  }
+                },
+                "pify": {
+                  "version": "2.3.0",
+                  "bundled": true
+                },
+                "pinkie": {
+                  "version": "2.0.4",
+                  "bundled": true
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "pinkie": "^2.0.0"
+                  }
+                },
+                "pkg-dir": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "find-up": "^1.0.0"
+                  },
+                  "dependencies": {
+                    "find-up": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "requires": {
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                      }
+                    }
+                  }
+                },
+                "preserve": {
+                  "version": "0.2.0",
+                  "bundled": true
+                },
+                "pseudomap": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "randomatic": {
+                  "version": "1.1.7",
+                  "bundled": true,
+                  "requires": {
+                    "is-number": "^3.0.0",
+                    "kind-of": "^4.0.0"
+                  },
+                  "dependencies": {
+                    "is-number": {
+                      "version": "3.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "kind-of": "^3.0.2"
+                      },
+                      "dependencies": {
+                        "kind-of": {
+                          "version": "3.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "is-buffer": "^1.1.5"
+                          }
+                        }
+                      }
+                    },
+                    "kind-of": {
+                      "version": "4.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "read-pkg": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "load-json-file": "^1.0.0",
+                    "normalize-package-data": "^2.3.2",
+                    "path-type": "^1.0.0"
+                  }
+                },
+                "read-pkg-up": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "find-up": "^1.0.0",
+                    "read-pkg": "^1.0.0"
+                  },
+                  "dependencies": {
+                    "find-up": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "requires": {
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                      }
+                    }
+                  }
+                },
+                "regenerator-runtime": {
+                  "version": "0.11.1",
+                  "bundled": true
+                },
+                "regex-cache": {
+                  "version": "0.4.4",
+                  "bundled": true,
+                  "requires": {
+                    "is-equal-shallow": "^0.1.3"
+                  }
+                },
+                "remove-trailing-separator": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "repeat-element": {
+                  "version": "1.1.2",
+                  "bundled": true
+                },
+                "repeat-string": {
+                  "version": "1.6.1",
+                  "bundled": true
+                },
+                "repeating": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-finite": "^1.0.0"
+                  }
+                },
+                "require-directory": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "require-main-filename": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "resolve-from": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "right-align": {
+                  "version": "0.1.3",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "align-text": "^0.1.1"
+                  }
+                },
+                "rimraf": {
+                  "version": "2.6.2",
+                  "bundled": true,
+                  "requires": {
+                    "glob": "^7.0.5"
+                  }
+                },
+                "semver": {
+                  "version": "5.4.1",
+                  "bundled": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "shebang-command": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "shebang-regex": "^1.0.0"
+                  }
+                },
+                "shebang-regex": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true
+                },
+                "slide": {
+                  "version": "1.1.6",
+                  "bundled": true
+                },
+                "source-map": {
+                  "version": "0.5.7",
+                  "bundled": true
+                },
+                "spawn-wrap": {
+                  "version": "1.4.2",
+                  "bundled": true,
+                  "requires": {
+                    "foreground-child": "^1.5.6",
+                    "mkdirp": "^0.5.0",
+                    "os-homedir": "^1.0.1",
+                    "rimraf": "^2.6.2",
+                    "signal-exit": "^3.0.2",
+                    "which": "^1.3.0"
+                  }
+                },
+                "spdx-correct": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "spdx-license-ids": "^1.0.2"
+                  }
+                },
+                "spdx-expression-parse": {
+                  "version": "1.0.4",
+                  "bundled": true
+                },
+                "spdx-license-ids": {
+                  "version": "1.2.2",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^4.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    },
+                    "strip-ansi": {
+                      "version": "4.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "^3.0.0"
+                      }
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^2.0.0"
+                  }
+                },
+                "strip-bom": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-utf8": "^0.2.0"
+                  }
+                },
+                "strip-eof": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "test-exclude": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "arrify": "^1.0.1",
+                    "micromatch": "^2.3.11",
+                    "object-assign": "^4.1.0",
+                    "read-pkg-up": "^1.0.1",
+                    "require-main-filename": "^1.0.1"
+                  }
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "bundled": true
+                },
+                "trim-right": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "uglify-js": {
+                  "version": "2.8.29",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "source-map": "~0.5.1",
+                    "uglify-to-browserify": "~1.0.0",
+                    "yargs": "~3.10.0"
+                  },
+                  "dependencies": {
+                    "yargs": {
+                      "version": "3.10.0",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "camelcase": "^1.0.2",
+                        "cliui": "^2.1.0",
+                        "decamelize": "^1.0.0",
+                        "window-size": "0.1.0"
+                      }
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "validate-npm-package-license": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "spdx-correct": "~1.0.0",
+                    "spdx-expression-parse": "~1.0.0"
+                  }
+                },
+                "which": {
+                  "version": "1.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "isexe": "^2.0.0"
+                  }
+                },
+                "which-module": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "bundled": true
+                },
+                "wrap-ansi": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1"
+                  },
+                  "dependencies": {
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                      }
+                    }
+                  }
+                },
+                "wrappy": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "write-file-atomic": {
+                  "version": "1.3.4",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "^4.1.11",
+                    "imurmurhash": "^0.1.4",
+                    "slide": "^1.1.5"
+                  }
+                },
+                "y18n": {
+                  "version": "3.2.1",
+                  "bundled": true
+                },
+                "yallist": {
+                  "version": "2.1.2",
+                  "bundled": true
+                },
+                "yargs": {
+                  "version": "10.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "cliui": "^3.2.0",
+                    "decamelize": "^1.1.1",
+                    "find-up": "^2.1.0",
+                    "get-caller-file": "^1.0.1",
+                    "os-locale": "^2.0.0",
+                    "require-directory": "^2.1.1",
+                    "require-main-filename": "^1.0.1",
+                    "set-blocking": "^2.0.0",
+                    "string-width": "^2.0.0",
+                    "which-module": "^2.0.0",
+                    "y18n": "^3.2.1",
+                    "yargs-parser": "^8.0.0"
+                  },
+                  "dependencies": {
+                    "cliui": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
+                      },
+                      "dependencies": {
+                        "string-width": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "code-point-at": "^1.0.0",
+                            "is-fullwidth-code-point": "^1.0.0",
+                            "strip-ansi": "^3.0.0"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "yargs-parser": {
+                  "version": "8.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "^4.1.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "4.1.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "os-locale": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
+              }
+            },
+            "sinon": {
+              "version": "4.3.0",
+              "bundled": true,
+              "requires": {
+                "@sinonjs/formatio": "^2.0.0",
+                "diff": "^3.1.0",
+                "lodash.get": "^4.4.2",
+                "lolex": "^2.2.0",
+                "nise": "^1.2.0",
+                "supports-color": "^5.1.0",
+                "type-detect": "^4.0.5"
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "yargs": {
+              "version": "11.0.0",
+              "bundled": true,
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
+              }
+            }
+          }
+        },
+        "@ladjs/time-require": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "chalk": "^0.4.0",
+            "date-time": "^0.1.1",
+            "pretty-ms": "^0.2.1",
+            "text-table": "^0.2.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "~1.0.0",
+                "has-color": "~0.1.0",
+                "strip-ansi": "~0.1.0"
+              }
+            },
+            "pretty-ms": {
+              "version": "0.2.2",
+              "bundled": true,
+              "requires": {
+                "parse-ms": "^0.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "0.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "@mrmlnc/readdir-enhanced": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "call-me-maybe": "^1.0.1",
+            "glob-to-regexp": "^0.3.0"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "@protobufjs/aspromise": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "@protobufjs/base64": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "@protobufjs/codegen": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "@protobufjs/eventemitter": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "@protobufjs/fetch": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.1",
+            "@protobufjs/inquire": "^1.1.0"
+          }
+        },
+        "@protobufjs/float": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "@protobufjs/inquire": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "@protobufjs/path": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "@protobufjs/pool": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "@protobufjs/utf8": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "@sindresorhus/is": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "@sinonjs/formatio": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "samsam": "1.3.0"
+          }
+        },
+        "@sinonjs/samsam": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "@types/long": {
+          "version": "3.0.32",
+          "bundled": true
+        },
+        "@types/node": {
+          "version": "8.10.21",
+          "bundled": true
+        },
+        "acorn": {
+          "version": "5.7.1",
+          "bundled": true
+        },
+        "acorn-es7-plugin": {
+          "version": "1.1.7",
+          "bundled": true
+        },
+        "acorn-jsx": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.0.3"
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "bundled": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "ansi-align": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "anymatch": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "micromatch": "^2.1.5",
+            "normalize-path": "^2.0.0"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            }
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "argv": {
+          "version": "0.0.2",
+          "bundled": true
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "arr-exclude": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "array-differ": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "array-filter": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "array-find": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "array-find-index": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "ascli": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "colour": "~0.7.1",
+            "optjs": "~3.2.2"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "async": {
+          "version": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "async-each": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "atob": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "auto-bind": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "ava": {
+          "version": "0.25.0",
+          "bundled": true,
+          "requires": {
+            "@ava/babel-preset-stage-4": "^1.1.0",
+            "@ava/babel-preset-transform-test-files": "^3.0.0",
+            "@ava/write-file-atomic": "^2.2.0",
+            "@concordance/react": "^1.0.0",
+            "@ladjs/time-require": "^0.1.4",
+            "ansi-escapes": "^3.0.0",
+            "ansi-styles": "^3.1.0",
+            "arr-flatten": "^1.0.1",
+            "array-union": "^1.0.1",
+            "array-uniq": "^1.0.2",
+            "arrify": "^1.0.0",
+            "auto-bind": "^1.1.0",
+            "ava-init": "^0.2.0",
+            "babel-core": "^6.17.0",
+            "babel-generator": "^6.26.0",
+            "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+            "bluebird": "^3.0.0",
+            "caching-transform": "^1.0.0",
+            "chalk": "^2.0.1",
+            "chokidar": "^1.4.2",
+            "clean-stack": "^1.1.1",
+            "clean-yaml-object": "^0.1.0",
+            "cli-cursor": "^2.1.0",
+            "cli-spinners": "^1.0.0",
+            "cli-truncate": "^1.0.0",
+            "co-with-promise": "^4.6.0",
+            "code-excerpt": "^2.1.1",
+            "common-path-prefix": "^1.0.0",
+            "concordance": "^3.0.0",
+            "convert-source-map": "^1.5.1",
+            "core-assert": "^0.2.0",
+            "currently-unhandled": "^0.4.1",
+            "debug": "^3.0.1",
+            "dot-prop": "^4.1.0",
+            "empower-core": "^0.6.1",
+            "equal-length": "^1.0.0",
+            "figures": "^2.0.0",
+            "find-cache-dir": "^1.0.0",
+            "fn-name": "^2.0.0",
+            "get-port": "^3.0.0",
+            "globby": "^6.0.0",
+            "has-flag": "^2.0.0",
+            "hullabaloo-config-manager": "^1.1.0",
+            "ignore-by-default": "^1.0.0",
+            "import-local": "^0.1.1",
+            "indent-string": "^3.0.0",
+            "is-ci": "^1.0.7",
+            "is-generator-fn": "^1.0.0",
+            "is-obj": "^1.0.0",
+            "is-observable": "^1.0.0",
+            "is-promise": "^2.1.0",
+            "last-line-stream": "^1.0.0",
+            "lodash.clonedeepwith": "^4.5.0",
+            "lodash.debounce": "^4.0.3",
+            "lodash.difference": "^4.3.0",
+            "lodash.flatten": "^4.2.0",
+            "loud-rejection": "^1.2.0",
+            "make-dir": "^1.0.0",
+            "matcher": "^1.0.0",
+            "md5-hex": "^2.0.0",
+            "meow": "^3.7.0",
+            "ms": "^2.0.0",
+            "multimatch": "^2.1.0",
+            "observable-to-promise": "^0.5.0",
+            "option-chain": "^1.0.0",
+            "package-hash": "^2.0.0",
+            "pkg-conf": "^2.0.0",
+            "plur": "^2.0.0",
+            "pretty-ms": "^3.0.0",
+            "require-precompiled": "^0.1.0",
+            "resolve-cwd": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "semver": "^5.4.1",
+            "slash": "^1.0.0",
+            "source-map-support": "^0.5.0",
+            "stack-utils": "^1.0.1",
+            "strip-ansi": "^4.0.0",
+            "strip-bom-buf": "^1.0.0",
+            "supertap": "^1.0.0",
+            "supports-color": "^5.0.0",
+            "trim-off-newlines": "^1.0.1",
+            "unique-temp-dir": "^1.0.0",
+            "update-notifier": "^2.3.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "empower-core": {
+              "version": "0.6.2",
+              "bundled": true,
+              "requires": {
+                "call-signature": "0.0.2",
+                "core-js": "^2.0.0"
+              }
+            },
+            "globby": {
+              "version": "6.1.0",
+              "bundled": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "pinkie": "^2.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ava-init": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "arr-exclude": "^1.0.0",
+            "execa": "^0.7.0",
+            "has-yarn": "^1.0.0",
+            "read-pkg-up": "^2.0.0",
+            "write-pkg": "^3.1.0"
+          }
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.7.0",
+          "bundled": true
+        },
+        "axios": {
+          "version": "0.18.0",
+          "bundled": true,
+          "requires": {
+            "follow-redirects": "^1.3.0",
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-core": {
+          "version": "6.26.3",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.1",
+            "debug": "^2.6.9",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.8",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.7"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.1",
+          "bundled": true,
+          "requires": {
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "1.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-helper-builder-binary-assignment-operator-visitor": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-explode-assignable-expression": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-call-delegate": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-explode-assignable-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-hoist-variables": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-regex": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-helper-remap-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-espower": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "babel-generator": "^6.1.0",
+            "babylon": "^6.1.0",
+            "call-matcher": "^1.0.0",
+            "core-js": "^2.0.0",
+            "espower-location-detector": "^1.0.0",
+            "espurify": "^1.6.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "babel-plugin-syntax-async-functions": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-exponentiation-operator": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-object-rest-spread": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-functions": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.26.2",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-strict-mode": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-types": "^6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-call-delegate": "^6.24.1",
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "regexpu-core": "^2.0.0"
+          }
+        },
+        "babel-plugin-transform-exponentiation-operator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-register": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
+          },
+          "dependencies": {
+            "source-map-support": {
+              "version": "0.4.18",
+              "bundled": true,
+              "requires": {
+                "source-map": "^0.5.6"
+              }
+            }
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "bundled": true,
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "binary-extensions": {
+          "version": "1.11.0",
+          "bundled": true
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "bundled": true
+        },
+        "boxen": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "ansi-align": "^2.0.0",
+            "camelcase": "^4.0.0",
+            "chalk": "^2.0.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^2.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "browser-stdout": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "buf-compare": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "buffer-equal-constant-time": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "buffer-from": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "bytebuffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "requires": {
+            "long": "~3"
+          },
+          "dependencies": {
+            "long": {
+              "version": "3.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          }
+        },
+        "cacheable-request": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "clone-response": "1.0.2",
+            "get-stream": "3.0.0",
+            "http-cache-semantics": "3.8.1",
+            "keyv": "3.0.0",
+            "lowercase-keys": "1.0.0",
+            "normalize-url": "2.0.1",
+            "responselike": "1.0.2"
+          },
+          "dependencies": {
+            "lowercase-keys": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
+          },
+          "dependencies": {
+            "md5-hex": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "md5-o-matic": "^0.1.1"
+              }
+            },
+            "write-file-atomic": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
+              }
+            }
+          }
+        },
+        "call-matcher": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.0.0",
+            "deep-equal": "^1.0.0",
+            "espurify": "^1.6.0",
+            "estraverse": "^4.0.0"
+          }
+        },
+        "call-me-maybe": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "call-signature": {
+          "version": "0.0.2",
+          "bundled": true
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "^0.2.0"
+          }
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "camelcase-keys": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
+          }
+        },
+        "capture-stack-trace": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "catharsis": {
+          "version": "0.8.9",
+          "bundled": true,
+          "requires": {
+            "underscore-contrib": "~0.3.0"
+          }
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
+          },
+          "dependencies": {
+            "glob-parent": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-glob": "^2.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            }
+          }
+        },
+        "ci-info": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "circular-json": {
+          "version": "0.3.3",
+          "bundled": true
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "clean-stack": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "clean-yaml-object": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "cli-spinners": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "cli-truncate": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "slice-ansi": "^1.0.0",
+            "string-width": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "clone-response": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "co-with-promise": {
+          "version": "4.6.0",
+          "bundled": true,
+          "requires": {
+            "pinkie-promise": "^1.0.0"
+          }
+        },
+        "code-excerpt": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "convert-to-spaces": "^1.0.1"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "codecov": {
+          "version": "https://registry.npmjs.org/codecov/-/codecov-3.0.4.tgz",
+          "bundled": true,
+          "requires": {
+            "argv": "^0.0.2",
+            "ignore-walk": "^3.0.1",
+            "request": "^2.87.0",
+            "urlgrey": "^0.4.4"
+          }
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.2",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.1"
+          }
+        },
+        "color-name": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "colors": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "colour": {
+          "version": "0.7.1",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.15.1",
+          "bundled": true
+        },
+        "common-path-prefix": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concordance": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "date-time": "^2.1.0",
+            "esutils": "^2.0.2",
+            "fast-diff": "^1.1.1",
+            "function-name-support": "^0.2.0",
+            "js-string-escape": "^1.0.1",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.flattendeep": "^4.4.0",
+            "lodash.merge": "^4.6.0",
+            "md5-hex": "^2.0.0",
+            "semver": "^5.3.0",
+            "well-known-symbols": "^1.0.0"
+          },
+          "dependencies": {
+            "date-time": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "time-zone": "^1.0.0"
+              }
+            }
+          }
+        },
+        "configstore": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "convert-to-spaces": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cookiejar": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "core-assert": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "buf-compare": "^1.0.0",
+            "is-error": "^2.2.0"
+          }
+        },
+        "core-js": {
+          "version": "2.5.7",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "capture-stack-trace": "^1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "crypto-random-string": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "currently-unhandled": {
+          "version": "0.4.1",
+          "bundled": true,
+          "requires": {
+            "array-find-index": "^1.0.1"
+          }
+        },
+        "d": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "es5-ext": "^0.10.9"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "date-time": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "decompress-response": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "define-properties": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "foreach": "^2.0.5",
+            "object-keys": "^1.0.8"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "del": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "globby": "^5.0.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "rimraf": "^2.2.8"
+          },
+          "dependencies": {
+            "globby": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "pinkie": "^2.0.0"
+              }
+            }
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "bundled": true
+        },
+        "diff-match-patch": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "dir-glob": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "path-type": "^3.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "dom-serializer": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "~1.1.1",
+            "entities": "~1.1.1"
+          },
+          "dependencies": {
+            "domelementtype": {
+              "version": "1.1.3",
+              "bundled": true
+            }
+          }
+        },
+        "domelementtype": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "domhandler": {
+          "version": "2.4.2",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "domutils": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "duplexify": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "eastasianwidth": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0"
+          }
+        },
+        "ecdsa-sig-formatter": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "empower": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.0.0",
+            "empower-core": "^1.2.0"
+          }
+        },
+        "empower-assert": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.2.0"
+          }
+        },
+        "empower-core": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "call-signature": "0.0.2",
+            "core-js": "^2.0.0"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "entities": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "equal-length": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.12.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.1",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.1"
+          }
+        },
+        "es5-ext": {
+          "version": "0.10.45",
+          "bundled": true,
+          "requires": {
+            "es6-iterator": "~2.0.3",
+            "es6-symbol": "~3.1.1",
+            "next-tick": "1"
+          }
+        },
+        "es6-error": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "es6-iterator": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "^0.10.35",
+            "es6-symbol": "^3.1.1"
+          }
+        },
+        "es6-map": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14",
+            "es6-iterator": "~2.0.1",
+            "es6-set": "~0.1.5",
+            "es6-symbol": "~3.1.1",
+            "event-emitter": "~0.3.5"
+          }
+        },
+        "es6-set": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14",
+            "es6-iterator": "~2.0.1",
+            "es6-symbol": "3.1.1",
+            "event-emitter": "~0.3.5"
+          }
+        },
+        "es6-symbol": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14"
+          }
+        },
+        "es6-weak-map": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "^0.10.14",
+            "es6-iterator": "^2.0.1",
+            "es6-symbol": "^3.1.1"
+          }
+        },
+        "escallmatch": {
+          "version": "1.5.0",
+          "bundled": true,
+          "requires": {
+            "call-matcher": "^1.0.0",
+            "esprima": "^2.0.0"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "2.7.3",
+              "bundled": true
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "escodegen": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "3.1.3",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "escope": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "es6-map": "^0.1.3",
+            "es6-weak-map": "^2.0.1",
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint": {
+          "version": "https://registry.npmjs.org/eslint/-/eslint-5.1.0.tgz",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.5.0",
+            "babel-code-frame": "^6.26.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^4.0.0",
+            "eslint-utils": "^1.3.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^4.0.0",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.7.0",
+            "ignore": "^3.3.3",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^5.2.0",
+            "is-resolvable": "^1.1.0",
+            "js-yaml": "^3.11.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.5",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^1.1.0",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.5.0",
+            "string.prototype.matchall": "^2.0.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "^2.0.1",
+            "table": "^4.0.3",
+            "text-table": "^0.2.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "6.5.2",
+              "bundled": true,
+              "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.1"
+              }
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "fast-deep-equal": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "globals": {
+              "version": "11.7.0",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.4.1",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "eslint-config-prettier": {
+          "version": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz",
+          "bundled": true,
+          "requires": {
+            "get-stdin": "^5.0.1"
+          },
+          "dependencies": {
+            "get-stdin": {
+              "version": "5.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-plugin-node": {
+          "version": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
+          "bundled": true,
+          "requires": {
+            "ignore": "^3.3.6",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.3.3",
+            "semver": "^5.4.1"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.8.1",
+              "bundled": true,
+              "requires": {
+                "path-parse": "^1.0.5"
+              }
+            }
+          }
+        },
+        "eslint-plugin-prettier": {
+          "version": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz",
+          "bundled": true,
+          "requires": {
+            "fast-diff": "^1.1.1",
+            "jest-docblock": "^21.0.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "espower": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "array-find": "^1.0.0",
+            "escallmatch": "^1.5.0",
+            "escodegen": "^1.7.0",
+            "escope": "^3.3.0",
+            "espower-location-detector": "^1.0.0",
+            "espurify": "^1.3.0",
+            "estraverse": "^4.1.0",
+            "source-map": "^0.5.0",
+            "type-name": "^2.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "espower-loader": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "convert-source-map": "^1.1.0",
+            "espower-source": "^2.0.0",
+            "minimatch": "^3.0.0",
+            "source-map-support": "^0.4.0",
+            "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "source-map-support": {
+              "version": "0.4.18",
+              "bundled": true,
+              "requires": {
+                "source-map": "^0.5.6"
+              }
+            }
+          }
+        },
+        "espower-location-detector": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-url": "^1.2.1",
+            "path-is-absolute": "^1.0.0",
+            "source-map": "^0.5.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "espower-source": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.0.0",
+            "acorn-es7-plugin": "^1.0.10",
+            "convert-source-map": "^1.1.1",
+            "empower-assert": "^1.0.0",
+            "escodegen": "^1.10.0",
+            "espower": "^2.1.1",
+            "estraverse": "^4.0.0",
+            "merge-estraverse-visitors": "^1.0.0",
+            "multi-stage-sourcemap": "^0.2.1",
+            "path-is-absolute": "^1.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "espree": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.6.0",
+            "acorn-jsx": "^4.1.1"
+          }
+        },
+        "esprima": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "espurify": {
+          "version": "1.8.1",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.0.0"
+          }
+        },
+        "esquery": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.0.0"
+          }
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.1.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "event-emitter": {
+          "version": "0.3.5",
+          "bundled": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "requires": {
+            "fill-range": "^2.1.0"
+          },
+          "dependencies": {
+            "fill-range": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
+              }
+            },
+            "is-number": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "isobject": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fast-diff": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "fast-glob": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.0.1",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.1",
+            "micromatch": "^3.1.10"
+          }
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fill-keys": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "is-object": "~1.0.1",
+            "merge-descriptors": "~1.0.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "flat-cache": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "circular-json": "^0.3.1",
+            "del": "^2.0.2",
+            "graceful-fs": "^4.1.2",
+            "write": "^0.2.1"
+          }
+        },
+        "fn-name": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "follow-redirects": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "debug": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "for-in": "^1.0.1"
+          }
+        },
+        "foreach": {
+          "version": "2.0.5",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "formidable": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "from2": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fsevents": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.9.2",
+            "node-pre-gyp": "^0.10.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.5.1",
+              "bundled": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.21",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": "^2.1.0"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.2.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.0",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.5.1",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.0.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.2.4",
+                "minizlib": "^1.1.0",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "function-name-support": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "gcp-metadata": {
+          "version": "0.6.3",
+          "bundled": true,
+          "requires": {
+            "axios": "^0.18.0",
+            "extend": "^3.0.1",
+            "retry-axios": "0.3.2"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-port": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
+          },
+          "dependencies": {
+            "glob-parent": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-glob": "^2.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            }
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "glob-to-regexp": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "global-dirs": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "ini": "^1.3.4"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true
+        },
+        "globby": {
+          "version": "8.0.1",
+          "bundled": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "1.6.1",
+          "bundled": true,
+          "requires": {
+            "axios": "^0.18.0",
+            "gcp-metadata": "^0.6.3",
+            "gtoken": "^2.3.0",
+            "jws": "^3.1.5",
+            "lodash.isstring": "^4.0.1",
+            "lru-cache": "^4.1.3",
+            "retry-axios": "^0.3.2"
+          }
+        },
+        "google-gax": {
+          "version": "0.17.1",
+          "bundled": true,
+          "requires": {
+            "duplexify": "^3.6.0",
+            "extend": "^3.0.1",
+            "globby": "^8.0.1",
+            "google-auth-library": "^1.6.1",
+            "google-proto-files": "^0.16.0",
+            "grpc": "^1.12.2",
+            "is-stream-ended": "^0.1.4",
+            "lodash": "^4.17.10",
+            "protobufjs": "^6.8.6",
+            "retry-request": "^4.0.0",
+            "through2": "^2.0.3"
+          }
+        },
+        "google-p12-pem": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "node-forge": "^0.7.4",
+            "pify": "^3.0.0"
+          }
+        },
+        "google-proto-files": {
+          "version": "0.16.1",
+          "bundled": true,
+          "requires": {
+            "globby": "^8.0.0",
+            "power-assert": "^1.4.4",
+            "protobufjs": "^6.8.0"
+          }
+        },
+        "got": {
+          "version": "8.2.0",
+          "bundled": true,
+          "requires": {
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.3.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
+            "url-to-options": "^1.0.1"
+          },
+          "dependencies": {
+            "prepend-http": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "url-parse-lax": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "prepend-http": "^2.0.0"
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "growl": {
+          "version": "1.10.5",
+          "bundled": true
+        },
+        "grpc": {
+          "version": "1.13.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.5",
+            "nan": "^2.0.0",
+            "node-pre-gyp": "^0.10.0",
+            "protobufjs": "^5.0.3"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "iconv-lite": {
+              "version": "0.4.23",
+              "bundled": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "minipass": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                }
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "needle": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.2",
+              "bundled": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.0",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "bundled": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "protobufjs": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ascli": "~1",
+                "bytebuffer": "~5",
+                "glob": "^7.0.5",
+                "yargs": "^3.10.0"
+              }
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "tar": {
+              "version": "4.4.4",
+              "bundled": true,
+              "requires": {
+                "chownr": "^1.0.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.3",
+                "minizlib": "^1.1.0",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "gtoken": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "axios": "^0.18.0",
+            "google-p12-pem": "^1.0.0",
+            "jws": "^3.1.4",
+            "mime": "^2.2.0",
+            "pify": "^3.0.0"
+          }
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-color": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "has-symbol-support-x": {
+          "version": "1.4.2",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "has-to-string-tag-x": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "has-symbol-support-x": "^1.4.1"
+          }
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "has-yarn": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "he": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "home-or-tmp": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.1"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "bundled": true
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "http-cache-semantics": {
+          "version": "3.8.1",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "hullabaloo-config-manager": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "dot-prop": "^4.1.0",
+            "es6-error": "^4.0.2",
+            "graceful-fs": "^4.1.11",
+            "indent-string": "^3.1.0",
+            "json5": "^0.5.1",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.clonedeepwith": "^4.5.0",
+            "lodash.isequal": "^4.5.0",
+            "lodash.merge": "^4.6.0",
+            "md5-hex": "^2.0.0",
+            "package-hash": "^2.0.0",
+            "pkg-dir": "^2.0.0",
+            "resolve-from": "^3.0.0",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "bundled": true
+        },
+        "ignore-by-default": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "import-lazy": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "import-local": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "pkg-dir": "^2.0.0",
+            "resolve-cwd": "^2.0.0"
+          }
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "ink-docstrap": {
+          "version": "https://registry.npmjs.org/ink-docstrap/-/ink-docstrap-1.3.2.tgz",
+          "bundled": true,
+          "requires": {
+            "moment": "^2.14.1",
+            "sanitize-html": "^1.13.0"
+          }
+        },
+        "inquirer": {
+          "version": "5.2.0",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "intelli-espower-loader": {
+          "version": "https://registry.npmjs.org/intelli-espower-loader/-/intelli-espower-loader-1.0.1.tgz",
+          "bundled": true,
+          "requires": {
+            "espower-loader": "^1.0.0"
+          }
+        },
+        "into-stream": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "from2": "^2.1.1",
+            "p-is-promise": "^1.1.0"
+          }
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "irregular-plurals": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "is-ci": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ci-info": "^1.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "is-primitive": "^2.0.0"
+          }
+        },
+        "is-error": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-generator-fn": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-installed-globally": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-observable": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "symbol-observable": "^1.1.0"
+          }
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "^1.0.1"
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-resolvable": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-stream-ended": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-url": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "@babel/generator": "7.0.0-beta.51",
+            "@babel/parser": "7.0.0-beta.51",
+            "@babel/template": "7.0.0-beta.51",
+            "@babel/traverse": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51",
+            "istanbul-lib-coverage": "^2.0.1",
+            "semver": "^5.5.0"
+          }
+        },
+        "isurl": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-to-string-tag-x": "^1.2.0",
+            "is-object": "^1.0.1"
+          }
+        },
+        "jest-docblock": {
+          "version": "21.2.0",
+          "bundled": true
+        },
+        "js-string-escape": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "bundled": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "js2xmlparser": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "xmlcreate": "^1.0.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsdoc": {
+          "version": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
+          "bundled": true,
+          "requires": {
+            "babylon": "7.0.0-beta.19",
+            "bluebird": "~3.5.0",
+            "catharsis": "~0.8.9",
+            "escape-string-regexp": "~1.0.5",
+            "js2xmlparser": "~3.0.0",
+            "klaw": "~2.0.0",
+            "marked": "~0.3.6",
+            "mkdirp": "~0.5.1",
+            "requizzle": "~0.2.1",
+            "strip-json-comments": "~2.0.1",
+            "taffydb": "2.6.2",
+            "underscore": "~1.8.3"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "7.0.0-beta.19",
+              "bundled": true
+            }
+          }
+        },
+        "jsesc": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "json-buffer": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "just-extend": {
+          "version": "1.1.27",
+          "bundled": true
+        },
+        "jwa": {
+          "version": "1.1.6",
+          "bundled": true,
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.10",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "3.1.5",
+          "bundled": true,
+          "requires": {
+            "jwa": "^1.1.5",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "keyv": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "json-buffer": "3.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "bundled": true
+        },
+        "klaw": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.9"
+          }
+        },
+        "last-line-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "through2": "^2.0.0"
+          }
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "package-json": "^4.0.0"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "bundled": true
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.clonedeepwith": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.debounce": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "lodash.difference": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.escaperegexp": {
+          "version": "4.1.2",
+          "bundled": true
+        },
+        "lodash.flatten": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lodash.get": {
+          "version": "4.4.2",
+          "bundled": true
+        },
+        "lodash.isequal": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "bundled": true
+        },
+        "lodash.isstring": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "lodash.merge": {
+          "version": "4.6.1",
+          "bundled": true
+        },
+        "lodash.mergewith": {
+          "version": "4.6.1",
+          "bundled": true
+        },
+        "lolex": {
+          "version": "2.7.1",
+          "bundled": true
+        },
+        "long": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "marked": {
+          "version": "0.3.19",
+          "bundled": true
+        },
+        "matcher": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.4"
+          }
+        },
+        "math-random": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "md5-hex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "md5-o-matic": "^0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "meow": {
+          "version": "3.7.0",
+          "bundled": true,
+          "requires": {
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "pinkie": "^2.0.0"
+              }
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "^0.2.0"
+              }
+            }
+          }
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "merge-estraverse-visitors": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.0.0"
+          }
+        },
+        "merge2": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "mime": {
+          "version": "2.3.1",
+          "bundled": true
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "bundled": true,
+          "requires": {
+            "mime-db": "~1.33.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "mimic-response": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "mocha": {
+          "version": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+          "bundled": true,
+          "requires": {
+            "browser-stdout": "1.3.1",
+            "commander": "2.15.1",
+            "debug": "3.1.0",
+            "diff": "3.5.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "growl": "1.10.5",
+            "he": "1.1.1",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "supports-color": "5.4.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "module-not-found-error": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "moment": {
+          "version": "2.22.2",
+          "bundled": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "multi-stage-sourcemap": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "source-map": "^0.1.34"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.43",
+              "bundled": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "multimatch": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "array-differ": "^1.0.0",
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "minimatch": "^3.0.0"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "nan": {
+          "version": "2.10.0",
+          "bundled": true
+        },
+        "nanomatch": {
+          "version": "1.2.13",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "next-tick": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "nice-try": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "nise": {
+          "version": "1.4.2",
+          "bundled": true,
+          "requires": {
+            "@sinonjs/formatio": "^2.0.0",
+            "just-extend": "^1.1.27",
+            "lolex": "^2.3.2",
+            "path-to-regexp": "^1.7.0",
+            "text-encoding": "^0.6.4"
+          }
+        },
+        "node-forge": {
+          "version": "0.7.5",
+          "bundled": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "normalize-url": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
+          },
+          "dependencies": {
+            "prepend-http": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "nyc": {
+          "version": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
+          "bundled": true,
+          "requires": {
+            "archy": "^1.0.0",
+            "arrify": "^1.0.1",
+            "caching-transform": "^1.0.0",
+            "convert-source-map": "^1.5.1",
+            "debug-log": "^1.0.1",
+            "default-require-extensions": "^1.0.0",
+            "find-cache-dir": "^0.1.1",
+            "find-up": "^2.1.0",
+            "foreground-child": "^1.5.3",
+            "glob": "^7.0.6",
+            "istanbul-lib-coverage": "^1.2.0",
+            "istanbul-lib-hook": "^1.1.0",
+            "istanbul-lib-instrument": "^2.1.0",
+            "istanbul-lib-report": "^1.1.3",
+            "istanbul-lib-source-maps": "^1.2.5",
+            "istanbul-reports": "^1.4.1",
+            "md5-hex": "^1.2.0",
+            "merge-source-map": "^1.1.0",
+            "micromatch": "^3.1.10",
+            "mkdirp": "^0.5.0",
+            "resolve-from": "^2.0.0",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.1",
+            "spawn-wrap": "^1.4.2",
+            "test-exclude": "^4.2.0",
+            "yargs": "11.1.0",
+            "yargs-parser": "^8.0.0"
+          },
+          "dependencies": {
+            "align-text": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
+              }
+            },
+            "amdefine": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "append-transform": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "default-require-extensions": "^1.0.0"
+              }
+            },
+            "archy": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "arr-diff": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "arr-flatten": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "arr-union": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "arrify": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "assign-symbols": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "async": {
+              "version": "1.5.2",
+              "bundled": true
+            },
+            "atob": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "base": {
+              "version": "0.11.2",
+              "bundled": true,
+              "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "braces": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "builtin-modules": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "cache-base": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+              }
+            },
+            "caching-transform": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "md5-hex": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "write-file-atomic": "^1.1.4"
+              }
+            },
+            "camelcase": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true
+            },
+            "center-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
+              }
+            },
+            "class-utils": {
+              "version": "0.3.6",
+              "bundled": true,
+              "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
+                "wordwrap": "0.0.2"
+              },
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "collection-visit": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+              }
+            },
+            "commondir": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "component-emitter": {
+              "version": "1.2.1",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "convert-source-map": {
+              "version": "1.5.1",
+              "bundled": true
+            },
+            "copy-descriptor": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
+              }
+            },
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "debug-log": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "decode-uri-component": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "default-require-extensions": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "strip-bom": "^2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+              },
+              "dependencies": {
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "error-ex": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "is-arrayish": "^0.2.1"
+              }
+            },
+            "execa": {
+              "version": "0.7.0",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              },
+              "dependencies": {
+                "cross-spawn": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "lru-cache": "^4.0.1",
+                    "shebang-command": "^1.2.0",
+                    "which": "^1.2.9"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "extend-shallow": {
+              "version": "3.0.2",
+              "bundled": true,
+              "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+              },
+              "dependencies": {
+                "is-extendable": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-plain-object": "^2.0.4"
+                  }
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "find-cache-dir": {
+              "version": "0.1.1",
+              "bundled": true,
+              "requires": {
+                "commondir": "^1.0.1",
+                "mkdirp": "^0.5.1",
+                "pkg-dir": "^1.0.0"
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "for-in": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "foreground-child": {
+              "version": "1.5.6",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "^4",
+                "signal-exit": "^3.0.0"
+              }
+            },
+            "fragment-cache": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "map-cache": "^0.2.2"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "get-caller-file": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "get-value": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true
+            },
+            "handlebars": {
+              "version": "4.0.11",
+              "bundled": true,
+              "requires": {
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.4.4",
+                  "bundled": true,
+                  "requires": {
+                    "amdefine": ">=0.0.4"
+                  }
+                }
+              }
+            },
+            "has-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+              }
+            },
+            "has-values": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "hosted-git-info": {
+              "version": "2.6.0",
+              "bundled": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "invert-kv": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-buffer": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "^1.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true
+                }
+              }
+            },
+            "is-extendable": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-odd": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-number": "^4.0.0"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "4.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "is-plain-object": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "isobject": "^3.0.1"
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-utf8": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-windows": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "istanbul-lib-coverage": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "istanbul-lib-hook": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "append-transform": "^0.4.0"
+              }
+            },
+            "istanbul-lib-report": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "istanbul-lib-coverage": "^1.1.2",
+                "mkdirp": "^0.5.1",
+                "path-parse": "^1.0.5",
+                "supports-color": "^3.1.2"
+              },
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "supports-color": {
+                  "version": "3.2.3",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "^1.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-lib-source-maps": {
+              "version": "1.2.5",
+              "bundled": true,
+              "requires": {
+                "debug": "^3.1.0",
+                "istanbul-lib-coverage": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.6.1",
+                "source-map": "^0.5.3"
+              }
+            },
+            "istanbul-reports": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "handlebars": "^4.0.3"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "lazy-cache": {
+              "version": "1.0.4",
+              "bundled": true,
+              "optional": true
+            },
+            "lcid": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "invert-kv": "^1.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              },
+              "dependencies": {
+                "path-exists": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "longest": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "lru-cache": {
+              "version": "4.1.3",
+              "bundled": true,
+              "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+              }
+            },
+            "map-cache": {
+              "version": "0.2.2",
+              "bundled": true
+            },
+            "map-visit": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "object-visit": "^1.0.0"
+              }
+            },
+            "md5-hex": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "md5-o-matic": "^0.1.1"
+              }
+            },
+            "md5-o-matic": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "mem": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "merge-source-map": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "source-map": "^0.6.1"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.6.1",
+                  "bundled": true
+                }
+              }
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "mimic-fn": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mixin-deep": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+              },
+              "dependencies": {
+                "is-extendable": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-plain-object": "^2.0.4"
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "nanomatch": {
+              "version": "1.2.9",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "normalize-package-data": {
+              "version": "2.4.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "npm-run-path": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "path-key": "^2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "object-copy": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "object-visit": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "isobject": "^3.0.0"
+              }
+            },
+            "object.pick": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "isobject": "^3.0.1"
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "os-locale": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
+              }
+            },
+            "p-finally": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "p-limit": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "pascalcase": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "path-parse": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "pinkie": "^2.0.0"
+              }
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "^2.0.0",
+                    "pinkie-promise": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "posix-character-classes": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "pseudomap": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "^2.0.0",
+                    "pinkie-promise": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "regex-not": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+              }
+            },
+            "repeat-element": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "repeat-string": {
+              "version": "1.6.1",
+              "bundled": true
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "require-main-filename": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "resolve-url": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "ret": {
+              "version": "0.1.15",
+              "bundled": true
+            },
+            "right-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "align-text": "^0.1.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-regex": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "ret": "~0.1.10"
+              }
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "set-value": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "slide": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "snapdragon": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "snapdragon-node": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "snapdragon-util": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.2.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "source-map-resolve": {
+              "version": "0.5.2",
+              "bundled": true,
+              "requires": {
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+              }
+            },
+            "source-map-url": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "spawn-wrap": {
+              "version": "1.4.2",
+              "bundled": true,
+              "requires": {
+                "foreground-child": "^1.5.6",
+                "mkdirp": "^0.5.0",
+                "os-homedir": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.2",
+                "which": "^1.3.0"
+              }
+            },
+            "spdx-correct": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "split-string": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^3.0.0"
+              }
+            },
+            "static-extend": {
+              "version": "0.1.2",
+              "bundled": true,
+              "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "^0.2.0"
+              }
+            },
+            "strip-eof": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "test-exclude": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "arrify": "^1.0.1",
+                "micromatch": "^3.1.8",
+                "object-assign": "^4.1.0",
+                "read-pkg-up": "^1.0.1",
+                "require-main-filename": "^1.0.1"
+              }
+            },
+            "to-object-path": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "to-regex": {
+              "version": "3.0.2",
+              "bundled": true,
+              "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+              }
+            },
+            "to-regex-range": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+              }
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
+              },
+              "dependencies": {
+                "yargs": {
+                  "version": "3.10.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "^1.0.2",
+                    "cliui": "^2.1.0",
+                    "decamelize": "^1.0.0",
+                    "window-size": "0.1.0"
+                  }
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "union-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "set-value": {
+                  "version": "0.4.3",
+                  "bundled": true,
+                  "requires": {
+                    "extend-shallow": "^2.0.1",
+                    "is-extendable": "^0.1.1",
+                    "is-plain-object": "^2.0.1",
+                    "to-object-path": "^0.3.0"
+                  }
+                }
+              }
+            },
+            "unset-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+              },
+              "dependencies": {
+                "has-value": {
+                  "version": "0.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "get-value": "^2.0.3",
+                    "has-values": "^0.1.4",
+                    "isobject": "^2.0.0"
+                  },
+                  "dependencies": {
+                    "isobject": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "isarray": "1.0.0"
+                      }
+                    }
+                  }
+                },
+                "has-values": {
+                  "version": "0.1.4",
+                  "bundled": true
+                }
+              }
+            },
+            "urix": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "use": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+              }
+            },
+            "which": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "bundled": true
+            },
+            "wrap-ansi": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "^1.0.0"
+                  }
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "write-file-atomic": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
+              }
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "11.1.0",
+              "bundled": true,
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "cliui": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "^2.1.1",
+                    "strip-ansi": "^4.0.0",
+                    "wrap-ansi": "^2.0.0"
+                  }
+                },
+                "yargs-parser": {
+                  "version": "9.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "^4.1.0"
+                  }
+                }
+              }
+            },
+            "yargs-parser": {
+              "version": "8.1.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "object-keys": {
+          "version": "1.0.12",
+          "bundled": true
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.0"
+          }
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "observable-to-promise": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "is-observable": "^0.2.0",
+            "symbol-observable": "^1.0.4"
+          },
+          "dependencies": {
+            "is-observable": {
+              "version": "0.2.0",
+              "bundled": true,
+              "requires": {
+                "symbol-observable": "^0.2.2"
+              },
+              "dependencies": {
+                "symbol-observable": {
+                  "version": "0.2.4",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "option-chain": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "optjs": {
+          "version": "3.2.2",
+          "bundled": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-is-promise": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-timeout": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "package-hash": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "lodash.flattendeep": "^4.4.0",
+            "md5-hex": "^2.0.0",
+            "release-zalgo": "^1.0.0"
+          }
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "got": "^6.7.1",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
+          },
+          "dependencies": {
+            "got": {
+              "version": "6.7.1",
+              "bundled": true,
+              "requires": {
+                "create-error-class": "^3.0.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "unzip-response": "^2.0.1",
+                "url-parse-lax": "^1.0.0"
+              }
+            }
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            }
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "parse-ms": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "path-dirname": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "isarray": "0.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "pinkie": "^1.0.0"
+          }
+        },
+        "pkg-conf": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "load-json-file": "^4.0.0"
+          },
+          "dependencies": {
+            "load-json-file": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            }
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
+        "plur": {
+          "version": "2.1.2",
+          "bundled": true,
+          "requires": {
+            "irregular-plurals": "^1.0.0"
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "power-assert": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "empower": "^1.3.0",
+            "power-assert-formatter": "^1.4.1",
+            "universal-deep-strict-equal": "^1.2.1",
+            "xtend": "^4.0.0"
+          }
+        },
+        "power-assert-context-formatter": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.0.0",
+            "power-assert-context-traversal": "^1.2.0"
+          }
+        },
+        "power-assert-context-reducer-ast": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.0.0",
+            "acorn-es7-plugin": "^1.0.12",
+            "core-js": "^2.0.0",
+            "espurify": "^1.6.0",
+            "estraverse": "^4.2.0"
+          }
+        },
+        "power-assert-context-traversal": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.0.0",
+            "estraverse": "^4.1.0"
+          }
+        },
+        "power-assert-formatter": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.0.0",
+            "power-assert-context-formatter": "^1.0.7",
+            "power-assert-context-reducer-ast": "^1.0.7",
+            "power-assert-renderer-assertion": "^1.0.7",
+            "power-assert-renderer-comparison": "^1.0.7",
+            "power-assert-renderer-diagram": "^1.0.7",
+            "power-assert-renderer-file": "^1.0.7"
+          }
+        },
+        "power-assert-renderer-assertion": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "power-assert-renderer-base": "^1.1.1",
+            "power-assert-util-string-width": "^1.2.0"
+          }
+        },
+        "power-assert-renderer-base": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "power-assert-renderer-comparison": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.0.0",
+            "diff-match-patch": "^1.0.0",
+            "power-assert-renderer-base": "^1.1.1",
+            "stringifier": "^1.3.0",
+            "type-name": "^2.0.1"
+          }
+        },
+        "power-assert-renderer-diagram": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.0.0",
+            "power-assert-renderer-base": "^1.1.1",
+            "power-assert-util-string-width": "^1.2.0",
+            "stringifier": "^1.3.0"
+          }
+        },
+        "power-assert-renderer-file": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "power-assert-renderer-base": "^1.1.1"
+          }
+        },
+        "power-assert-util-string-width": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "eastasianwidth": "^0.2.0"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "prettier": {
+          "version": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
+          "bundled": true
+        },
+        "pretty-ms": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "parse-ms": "^1.0.0"
+          },
+          "dependencies": {
+            "parse-ms": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "private": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "progress": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "protobufjs": {
+          "version": "6.8.6",
+          "bundled": true,
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^3.0.32",
+            "@types/node": "^8.9.4",
+            "long": "^4.0.0"
+          }
+        },
+        "proxyquire": {
+          "version": "1.8.0",
+          "bundled": true,
+          "requires": {
+            "fill-keys": "^1.0.2",
+            "module-not-found-error": "^1.0.0",
+            "resolve": "~1.1.7"
+          }
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "pump": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "randomatic": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "^4.0.0",
+            "kind-of": "^6.0.0",
+            "math-random": "^1.0.1"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          },
+          "dependencies": {
+            "path-type": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^3.0.2",
+            "readable-stream": "^2.0.2",
+            "set-immediate-shim": "^1.0.1"
+          }
+        },
+        "redent": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
+          },
+          "dependencies": {
+            "indent-string": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "repeating": "^2.0.0"
+              }
+            }
+          }
+        },
+        "regenerate": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "bundled": true,
+          "requires": {
+            "is-equal-shallow": "^0.1.3"
+          }
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "regexp.prototype.flags": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2"
+          }
+        },
+        "regexpp": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        },
+        "registry-auth-token": {
+          "version": "3.3.2",
+          "bundled": true,
+          "requires": {
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "rc": "^1.0.1"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        },
+        "release-zalgo": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "es6-error": "^4.0.1"
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
+        },
+        "request": {
+          "version": "2.87.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "require-precompiled": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
+          },
+          "dependencies": {
+            "resolve-from": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "requizzle": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "underscore": "~1.6.0"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.6.0",
+              "bundled": true
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "bundled": true
+        },
+        "resolve-cwd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "responselike": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "lowercase-keys": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "ret": {
+          "version": "0.1.15",
+          "bundled": true
+        },
+        "retry-axios": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "retry-request": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "through2": "^2.0.0"
+          }
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "rxjs": {
+          "version": "5.5.11",
+          "bundled": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          },
+          "dependencies": {
+            "symbol-observable": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "samsam": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "sanitize-html": {
+          "version": "1.18.2",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.3.0",
+            "htmlparser2": "^3.9.0",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.escaperegexp": "^4.1.2",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.mergewith": "^4.6.0",
+            "postcss": "^6.0.14",
+            "srcset": "^1.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "semver": "^5.0.3"
+          }
+        },
+        "serialize-error": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "set-immediate-shim": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "sinon": {
+          "version": "https://registry.npmjs.org/sinon/-/sinon-6.1.3.tgz",
+          "bundled": true,
+          "requires": {
+            "@sinonjs/formatio": "^2.0.0",
+            "@sinonjs/samsam": "^2.0.0",
+            "diff": "^3.5.0",
+            "lodash.get": "^4.4.2",
+            "lolex": "^2.4.2",
+            "nise": "^1.3.3",
+            "supports-color": "^5.4.0",
+            "type-detect": "^4.0.8"
+          }
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.2.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "sort-keys": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.2",
+          "bundled": true,
+          "requires": {
+            "atob": "^2.1.1",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-support": {
+          "version": "0.5.6",
+          "bundled": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "srcset": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "array-uniq": "^1.0.2",
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "sshpk": {
+          "version": "1.14.2",
+          "bundled": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "stack-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "stream-events": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "stubs": "^3.0.0"
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "string": {
+          "version": "3.3.3",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string.prototype.matchall": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.10.0",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "regexp.prototype.flags": "^1.2.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "stringifier": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.0.0",
+            "traverse": "^0.6.6",
+            "type-name": "^2.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "strip-bom-buf": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-utf8": "^0.2.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "get-stdin": "^4.0.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "stubs": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "superagent": {
+          "version": "3.8.3",
+          "bundled": true,
+          "requires": {
+            "component-emitter": "^1.2.0",
+            "cookiejar": "^2.1.0",
+            "debug": "^3.1.0",
+            "extend": "^3.0.0",
+            "form-data": "^2.3.1",
+            "formidable": "^1.2.0",
+            "methods": "^1.1.1",
+            "mime": "^1.4.1",
+            "qs": "^6.5.1",
+            "readable-stream": "^2.3.5"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "mime": {
+              "version": "1.6.0",
+              "bundled": true
+            }
+          }
+        },
+        "supertap": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "indent-string": "^3.2.0",
+            "js-yaml": "^3.10.0",
+            "serialize-error": "^2.1.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "supertest": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "methods": "~1.1.2",
+            "superagent": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "symbol-observable": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "table": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.0.1",
+            "ajv-keywords": "^3.0.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "6.5.2",
+              "bundled": true,
+              "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.1"
+              }
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "fast-deep-equal": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.4.1",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "taffydb": {
+          "version": "2.6.2",
+          "bundled": true
+        },
+        "term-size": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "execa": "^0.7.0"
+          }
+        },
+        "text-encoding": {
+          "version": "0.6.4",
+          "bundled": true
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        },
+        "time-zone": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "bundled": true,
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        },
+        "traverse": {
+          "version": "0.6.6",
+          "bundled": true
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "trim-off-newlines": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "type-name": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
+                "wordwrap": "0.0.2"
+              }
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "uid2": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "bundled": true
+        },
+        "underscore-contrib": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.6.0"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.6.0",
+              "bundled": true
+            }
+          }
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+              }
+            }
+          }
+        },
+        "unique-string": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "crypto-random-string": "^1.0.0"
+          }
+        },
+        "unique-temp-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "^0.5.1",
+            "os-tmpdir": "^1.0.1",
+            "uid2": "0.0.3"
+          }
+        },
+        "universal-deep-strict-equal": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "array-filter": "^1.0.0",
+            "indexof": "0.0.1",
+            "object-keys": "^1.0.0"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "bundled": true,
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "bundled": true
+            }
+          }
+        },
+        "unzip-response": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "update-notifier": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^1.0.10",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "url-to-options": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "urlgrey": {
+          "version": "0.4.4",
+          "bundled": true
+        },
+        "use": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^6.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "well-known-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "widest-line": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "window-size": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "write-file-atomic": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "write-json-file": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "detect-indent": "^5.0.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "pify": "^3.0.0",
+            "sort-keys": "^2.0.0",
+            "write-file-atomic": "^2.0.0"
+          },
+          "dependencies": {
+            "detect-indent": {
+              "version": "5.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "write-pkg": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "sort-keys": "^2.0.0",
+            "write-json-file": "^2.2.0"
+          }
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "xmlcreate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true
+            }
+          }
+        }
       }
     },
     "@google-cloud/storage": {
@@ -381,74 +10857,6 @@
         }
       }
     },
-    "@mrmlnc/readdir-enhanced": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz",
-      "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A=="
-    },
-    "@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
-    },
-    "@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
-    },
-    "@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
-    },
-    "@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
-    },
-    "@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
-    },
-    "@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
-    },
-    "@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
-    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -463,32 +10871,6 @@
       "requires": {
         "samsam": "1.3.0"
       }
-    },
-    "@sinonjs/samsam": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
-      "integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg==",
-      "dev": true
-    },
-    "@types/long": {
-      "version": "3.0.32",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
-      "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
-    },
-    "@types/node": {
-      "version": "8.10.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.21.tgz",
-      "integrity": "sha512-87XkD9qDXm8fIax+5y7drx84cXsu34ZZqfB7Cial3Q/2lxSoJ/+DRaWckkCbxP41wFSIrrb939VhzaNxj4eY1w=="
-    },
-    "acorn": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
-    },
-    "acorn-es7-plugin": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz",
-      "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s="
     },
     "ajv": {
       "version": "5.5.2",
@@ -701,11 +11083,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "arr-diff": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-    },
     "arr-exclude": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
@@ -715,23 +11092,14 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-    },
-    "arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
     },
     "array-differ": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
-    },
-    "array-filter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -743,6 +11111,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
       "requires": {
         "array-uniq": "^1.0.1"
       }
@@ -752,24 +11121,10 @@
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
-    "array-unique": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-    },
-    "ascli": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
-      "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
-      "requires": {
-        "colour": "~0.7.1",
-        "optjs": "~3.2.2"
-      }
     },
     "asn1": {
       "version": "0.2.3",
@@ -780,11 +11135,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "async": {
       "version": "2.6.1",
@@ -804,11 +11154,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "atob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
     },
     "auto-bind": {
       "version": "1.2.1",
@@ -1452,62 +11797,13 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-      "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
-      }
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -1583,36 +11879,10 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-      "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
       }
     },
     "buf-compare": {
@@ -1636,37 +11906,6 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
-    },
-    "bytebuffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
-      "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
-      "requires": {
-        "long": "~3"
-      },
-      "dependencies": {
-        "long": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
-        }
-      }
-    },
-    "cache-base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-      "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
-      }
     },
     "cacheable-request": {
       "version": "2.1.4",
@@ -1736,20 +11975,17 @@
         "estraverse": "^4.0.0"
       }
     },
-    "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
-    },
     "call-signature": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
+      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
+      "dev": true
     },
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -1842,27 +12078,6 @@
       "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
       "dev": true
     },
-    "class-utils": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        }
-      }
-    },
     "clean-stack": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
@@ -1939,16 +12154,6 @@
         }
       }
     },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -1986,15 +12191,6 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
-    "collection-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-      "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
-      }
-    },
     "color-convert": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
@@ -2015,11 +12211,6 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
-    },
-    "colour": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -2044,7 +12235,8 @@
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "compressible": {
       "version": "2.0.14",
@@ -2064,7 +12256,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -2138,11 +12331,6 @@
       "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true
     },
-    "copy-descriptor": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-    },
     "core-assert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
@@ -2156,7 +12344,8 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2213,6 +12402,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -2225,7 +12415,8 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -2248,52 +12439,6 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
-    "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
-      }
-    },
-    "define-property": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-      "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
-      },
-      "dependencies": {
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2313,20 +12458,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
-    },
-    "diff-match-patch": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.1.tgz",
-      "integrity": "sha512-A0QEhr4PxGUMEtKxd6X+JLnOTFd3BfIPSDpsc4dMvj+CbSaErDwTpoTo/nFJDMSrjxLW4BiNq+FbNisAAHhWeQ=="
-    },
-    "dir-glob": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-      "requires": {
-        "arrify": "^1.0.1",
-        "path-type": "^3.0.0"
-      }
     },
     "dot-prop": {
       "version": "4.2.0",
@@ -2353,11 +12484,6 @@
         "stream-shift": "^1.0.0"
       }
     },
-    "eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
-    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -2373,24 +12499,6 @@
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "empower": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/empower/-/empower-1.3.0.tgz",
-      "integrity": "sha512-tP2WqM7QzrPguCCQEQfFFDF+6Pw6YWLQal3+GHQaV+0uIr0S+jyREQPWljE02zFCYPFYLZ3LosiRV+OzTrxPpQ==",
-      "requires": {
-        "core-js": "^2.0.0",
-        "empower-core": "^1.2.0"
-      }
-    },
-    "empower-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-1.2.0.tgz",
-      "integrity": "sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==",
-      "requires": {
-        "call-signature": "0.0.2",
-        "core-js": "^2.0.0"
       }
     },
     "end-of-stream": {
@@ -2452,9 +12560,10 @@
       "dev": true
     },
     "espurify": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
-      "integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
+      "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
+      "dev": true,
       "requires": {
         "core-js": "^2.0.0"
       }
@@ -2462,7 +12571,8 @@
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
@@ -2482,38 +12592,6 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
-      }
-    },
-    "expand-brackets": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-      "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
       }
     },
     "expand-range": {
@@ -2572,84 +12650,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
-    "extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-      "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
-      }
-    },
-    "extglob": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-      "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
-      }
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -2665,19 +12665,6 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
       "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
       "dev": true
-    },
-    "fast-glob": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
-      "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
-      "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.0.1",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.1",
-        "micromatch": "^3.1.10"
-      }
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -2709,27 +12696,6 @@
         "merge-descriptors": "~1.0.0"
       }
     },
-    "fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
-      }
-    },
     "find-cache-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
@@ -2742,11 +12708,11 @@
       }
     },
     "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "fn-name": {
@@ -2756,9 +12722,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
-      "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
       "requires": {
         "debug": "^3.1.0"
       },
@@ -2776,7 +12742,8 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
     },
     "for-own": {
       "version": "0.1.5",
@@ -2786,11 +12753,6 @@
       "requires": {
         "for-in": "^1.0.1"
       }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2812,14 +12774,6 @@
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
       "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
       "dev": true
-    },
-    "fragment-cache": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-      "requires": {
-        "map-cache": "^0.2.2"
-      }
     },
     "from2": {
       "version": "2.3.0",
@@ -2845,7 +12799,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.4",
@@ -2860,24 +12815,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2887,12 +12846,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -2901,34 +12862,40 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2937,25 +12904,29 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2964,13 +12935,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2986,7 +12959,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3000,13 +12974,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3015,7 +12991,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3024,7 +13001,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3034,18 +13012,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -3053,13 +13034,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -3067,12 +13050,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1",
@@ -3081,7 +13066,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3090,7 +13076,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -3098,13 +13085,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3115,7 +13104,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3133,7 +13123,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3143,13 +13134,15 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3159,7 +13152,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3171,18 +13165,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -3190,19 +13187,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3212,19 +13212,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3236,7 +13239,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -3244,7 +13248,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3259,7 +13264,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3268,42 +13274,49 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -3313,7 +13326,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3322,7 +13336,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -3330,13 +13345,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3351,13 +13368,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3366,12 +13385,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
       }
@@ -3426,11 +13447,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
-    "get-value": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
-    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -3443,6 +13459,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3488,30 +13505,6 @@
         }
       }
     },
-    "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-      "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
-      }
-    },
-    "glob-to-regexp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
-    },
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -3526,20 +13519,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
-    },
-    "globby": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-      "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
-      "requires": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "fast-glob": "^2.0.2",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
-      }
     },
     "google-auth-library": {
       "version": "1.6.1",
@@ -3566,23 +13545,6 @@
         "request": "^2.79.0"
       }
     },
-    "google-gax": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.16.1.tgz",
-      "integrity": "sha512-eP7UUkKvaHmmvCrr+rxzkIOeEKOnXmoib7/AkENDAuqlC9T2+lWlzwpthDRnitQcV8SblDMzsk73YPMPCDwPyQ==",
-      "requires": {
-        "duplexify": "^3.5.4",
-        "extend": "^3.0.0",
-        "globby": "^8.0.0",
-        "google-auto-auth": "^0.10.0",
-        "google-proto-files": "^0.15.0",
-        "grpc": "^1.10.0",
-        "is-stream-ended": "^0.1.0",
-        "lodash": "^4.17.2",
-        "protobufjs": "^6.8.0",
-        "through2": "^2.0.3"
-      }
-    },
     "google-p12-pem": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
@@ -3590,31 +13552,6 @@
       "requires": {
         "node-forge": "^0.7.4",
         "pify": "^3.0.0"
-      }
-    },
-    "google-proto-files": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.15.1.tgz",
-      "integrity": "sha512-ebtmWgi/ooR5Nl63qRVZZ6VLM6JOb5zTNxTT/ZAU8yfMOdcauoOZNNMOVg0pCmTjqWXeuuVbgPP0CwO5UHHzBQ==",
-      "requires": {
-        "globby": "^7.1.1",
-        "power-assert": "^1.4.4",
-        "protobufjs": "^6.8.0"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-          "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
-          }
-        }
       }
     },
     "got": {
@@ -3663,447 +13600,6 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "grpc": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.13.0.tgz",
-      "integrity": "sha512-jGxWFYzttSz9pi8mu283jZvo2zIluWonQ918GMHKx8grT57GIVlvx7/82fo7AGS75lbkPoO1T6PZLvCRD9Pbtw==",
-      "requires": {
-        "lodash": "^4.17.5",
-        "nan": "^2.0.0",
-        "node-pre-gyp": "^0.10.0",
-        "protobufjs": "^5.0.3"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "iconv-lite": {
-          "version": "0.4.23",
-          "bundled": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "minipass": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            }
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "needle": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.2",
-          "bundled": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "protobufjs": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
-          "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
-          "requires": {
-            "ascli": "~1",
-            "bytebuffer": "~5",
-            "glob": "^7.0.5",
-            "yargs": "^3.10.0"
-          }
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "tar": {
-          "version": "4.4.4",
-          "bundled": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.3",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-          "requires": {
-            "camelcase": "^2.0.1",
-            "cliui": "^3.0.3",
-            "decamelize": "^1.1.1",
-            "os-locale": "^1.4.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.1.4",
-            "y18n": "^3.2.0"
-          }
-        }
-      }
     },
     "gtoken": {
       "version": "2.3.0",
@@ -4196,35 +13692,6 @@
         "has-symbol-support-x": "^1.4.1"
       }
     },
-    "has-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-      "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
-      }
-    },
-    "has-values": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-      "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "has-yarn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
@@ -4250,9 +13717,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
+      "integrity": "sha512-Ba4+0M4YvIDUUsprMjhVTU1yN9F2/LJSAl69ZpzaLT4l4j5mwTS6jqqW9Ojvj6lKz/veqPzpJBqGbXspOb533A==",
       "dev": true
     },
     "http-cache-semantics": {
@@ -4293,11 +13760,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "ignore": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
-    },
     "ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
@@ -4331,15 +13793,11 @@
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4391,24 +13849,6 @@
       "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
       "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU="
     },
-    "is-accessor-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4447,41 +13887,6 @@
         "ci-info": "^1.0.0"
       }
     },
-    "is-data-descriptor": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "is-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-      "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -4506,12 +13911,8 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -4536,14 +13937,6 @@
       "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
       "dev": true
     },
-    "is-glob": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
     "is-installed-globally": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
@@ -4559,24 +13952,6 @@
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
       "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "dev": true
-    },
-    "is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
     },
     "is-obj": {
       "version": "1.0.1",
@@ -4612,14 +13987,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
-    },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "requires": {
-        "isobject": "^3.0.1"
-      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -4678,11 +14045,6 @@
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
-    "is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4692,11 +14054,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
@@ -4837,7 +14194,8 @@
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
     },
     "last-line-stream": {
       "version": "1.0.0",
@@ -4893,11 +14251,11 @@
       }
     },
     "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "^3.0.0",
+        "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
       }
     },
@@ -4962,7 +14320,8 @@
     "lodash.merge": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "dev": true
     },
     "log-driver": {
       "version": "1.2.7",
@@ -4970,15 +14329,10 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
     },
     "lolex": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
-      "integrity": "sha512-Oo2Si3RMKV3+lV5MsSWplDQFoTClz/24S0MMHYcgGWWmFXr6TMlqcqk/l1GtH+d5wLBwNRiqGnwDRMirtFalJw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
+      "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
       "dev": true
-    },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "longest": {
       "version": "1.0.1",
@@ -4987,12 +14341,12 @@
       "dev": true
     },
     "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "^3.0.0"
       }
     },
     "loud-rejection": {
@@ -5028,24 +14382,11 @@
         "pify": "^3.0.0"
       }
     },
-    "map-cache": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
-    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
-    },
-    "map-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "requires": {
-        "object-visit": "^1.0.0"
-      }
     },
     "matcher": {
       "version": "1.1.1",
@@ -5211,11 +14552,6 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
-    "merge2": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
-      "integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
-    },
     "methmeth": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/methmeth/-/methmeth-1.1.0.tgz",
@@ -5226,26 +14562,6 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
-    },
-    "micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-      "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      }
     },
     "mime": {
       "version": "2.3.1",
@@ -5280,6 +14596,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -5289,25 +14606,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
-    },
-    "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-      "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
-      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -5349,25 +14647,9 @@
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-    },
-    "nanomatch": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-      "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      }
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true,
+      "optional": true
     },
     "nise": {
       "version": "1.4.2",
@@ -5482,7 +14764,8 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2",
@@ -5492,22 +14775,26 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "dev": true,
           "requires": {
             "default-require-extensions": "^1.0.0"
@@ -5515,12 +14802,14 @@
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arr-diff": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.0.1"
@@ -5528,27 +14817,32 @@
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
           "dev": true
         },
         "array-unique": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "babel-code-frame": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -5558,7 +14852,8 @@
         },
         "babel-generator": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+          "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
           "dev": true,
           "requires": {
             "babel-messages": "^6.23.0",
@@ -5573,7 +14868,8 @@
         },
         "babel-messages": {
           "version": "6.23.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
             "babel-runtime": "^6.22.0"
@@ -5581,7 +14877,8 @@
         },
         "babel-runtime": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
             "core-js": "^2.4.0",
@@ -5590,7 +14887,8 @@
         },
         "babel-template": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
@@ -5602,7 +14900,8 @@
         },
         "babel-traverse": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
             "babel-code-frame": "^6.26.0",
@@ -5618,7 +14917,8 @@
         },
         "babel-types": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
@@ -5629,17 +14929,20 @@
         },
         "babylon": {
           "version": "6.18.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -5648,7 +14951,8 @@
         },
         "braces": {
           "version": "1.8.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
             "expand-range": "^1.8.1",
@@ -5658,12 +14962,14 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "caching-transform": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "dev": true,
           "requires": {
             "md5-hex": "^1.2.0",
@@ -5673,13 +14979,15 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5689,7 +14997,8 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -5701,7 +15010,8 @@
         },
         "cliui": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5712,7 +15022,8 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
               "dev": true,
               "optional": true
             }
@@ -5720,32 +15031,38 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "commondir": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
           "dev": true
         },
         "core-js": {
           "version": "2.5.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -5754,7 +15071,8 @@
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -5762,17 +15080,20 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "dev": true,
           "requires": {
             "strip-bom": "^2.0.0"
@@ -5780,7 +15101,8 @@
         },
         "detect-indent": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
             "repeating": "^2.0.0"
@@ -5788,7 +15110,8 @@
         },
         "error-ex": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
@@ -5796,17 +15119,20 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -5820,7 +15146,8 @@
           "dependencies": {
             "cross-spawn": {
               "version": "5.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
               "dev": true,
               "requires": {
                 "lru-cache": "^4.0.1",
@@ -5832,7 +15159,8 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
             "is-posix-bracket": "^0.1.0"
@@ -5840,7 +15168,8 @@
         },
         "expand-range": {
           "version": "1.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "dev": true,
           "requires": {
             "fill-range": "^2.1.0"
@@ -5848,7 +15177,8 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
@@ -5856,12 +15186,14 @@
         },
         "filename-regex": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
           "dev": true
         },
         "fill-range": {
           "version": "2.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "dev": true,
           "requires": {
             "is-number": "^2.1.0",
@@ -5873,7 +15205,8 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
@@ -5883,7 +15216,8 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -5891,12 +15225,14 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         },
         "for-own": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
             "for-in": "^1.0.1"
@@ -5904,7 +15240,8 @@
         },
         "foreground-child": {
           "version": "1.5.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
             "cross-spawn": "^4",
@@ -5913,22 +15250,26 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -5941,7 +15282,8 @@
         },
         "glob-base": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
           "dev": true,
           "requires": {
             "glob-parent": "^2.0.0",
@@ -5950,7 +15292,8 @@
         },
         "glob-parent": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
             "is-glob": "^2.0.0"
@@ -5958,17 +15301,20 @@
         },
         "globals": {
           "version": "9.18.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
           "dev": true,
           "requires": {
             "async": "^1.4.0",
@@ -5979,7 +15325,8 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
                 "amdefine": ">=0.0.4"
@@ -5989,7 +15336,8 @@
         },
         "has-ansi": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5997,22 +15345,26 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -6021,12 +15373,14 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invariant": {
           "version": "2.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
             "loose-envify": "^1.0.0"
@@ -6034,22 +15388,26 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
             "builtin-modules": "^1.0.0"
@@ -6057,12 +15415,14 @@
         },
         "is-dotfile": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
           "dev": true
         },
         "is-equal-shallow": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
           "dev": true,
           "requires": {
             "is-primitive": "^2.0.0"
@@ -6070,17 +15430,20 @@
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -6088,7 +15451,8 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -6096,7 +15460,8 @@
         },
         "is-glob": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
@@ -6104,7 +15469,8 @@
         },
         "is-number": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -6112,37 +15478,44 @@
         },
         "is-posix-bracket": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
           "dev": true
         },
         "is-primitive": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true,
           "requires": {
             "isarray": "1.0.0"
@@ -6150,12 +15523,14 @@
         },
         "istanbul-lib-coverage": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+          "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+          "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
           "dev": true,
           "requires": {
             "append-transform": "^0.4.0"
@@ -6163,7 +15538,8 @@
         },
         "istanbul-lib-instrument": {
           "version": "1.9.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
+          "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
           "dev": true,
           "requires": {
             "babel-generator": "^6.18.0",
@@ -6177,7 +15553,8 @@
         },
         "istanbul-lib-report": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
+          "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "^1.1.1",
@@ -6188,7 +15565,8 @@
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "dev": true,
               "requires": {
                 "has-flag": "^1.0.0"
@@ -6198,7 +15576,8 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
+          "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
           "dev": true,
           "requires": {
             "debug": "^3.1.0",
@@ -6210,7 +15589,8 @@
           "dependencies": {
             "debug": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
               "dev": true,
               "requires": {
                 "ms": "2.0.0"
@@ -6220,7 +15600,8 @@
         },
         "istanbul-reports": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
+          "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
           "dev": true,
           "requires": {
             "handlebars": "^4.0.3"
@@ -6228,17 +15609,20 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -6246,13 +15630,15 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
@@ -6260,7 +15646,8 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -6272,7 +15659,8 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -6281,24 +15669,28 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
               "dev": true
             }
           }
         },
         "lodash": {
           "version": "4.17.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
           "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
             "js-tokens": "^3.0.0"
@@ -6306,7 +15698,8 @@
         },
         "lru-cache": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -6315,7 +15708,8 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
             "md5-o-matic": "^0.1.1"
@@ -6323,12 +15717,14 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -6336,7 +15732,8 @@
         },
         "merge-source-map": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+          "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
           "dev": true,
           "requires": {
             "source-map": "^0.5.6"
@@ -6344,7 +15741,8 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
             "arr-diff": "^2.0.0",
@@ -6364,12 +15762,14 @@
         },
         "mimic-fn": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -6377,12 +15777,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -6390,12 +15792,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -6406,7 +15810,8 @@
         },
         "normalize-path": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
@@ -6414,7 +15819,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -6422,17 +15828,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object.omit": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
           "dev": true,
           "requires": {
             "for-own": "^0.1.4",
@@ -6441,7 +15850,8 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -6449,7 +15859,8 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
             "minimist": "~0.0.1",
@@ -6458,12 +15869,14 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -6473,17 +15886,20 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
           "dev": true
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -6491,7 +15907,8 @@
         },
         "parse-glob": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
           "dev": true,
           "requires": {
             "glob-base": "^0.3.0",
@@ -6502,7 +15919,8 @@
         },
         "parse-json": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
@@ -6510,7 +15928,8 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -6518,22 +15937,26 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -6543,17 +15966,20 @@
         },
         "pify": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
             "pinkie": "^2.0.0"
@@ -6561,7 +15987,8 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
             "find-up": "^1.0.0"
@@ -6569,7 +15996,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -6580,17 +16008,20 @@
         },
         "preserve": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "randomatic": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+          "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -6599,7 +16030,8 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
@@ -6607,7 +16039,8 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
@@ -6617,7 +16050,8 @@
             },
             "kind-of": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -6627,7 +16061,8 @@
         },
         "read-pkg": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
             "load-json-file": "^1.0.0",
@@ -6637,7 +16072,8 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
             "find-up": "^1.0.0",
@@ -6646,7 +16082,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -6657,12 +16094,14 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
         },
         "regex-cache": {
           "version": "0.4.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+          "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
           "dev": true,
           "requires": {
             "is-equal-shallow": "^0.1.3"
@@ -6670,22 +16109,26 @@
         },
         "remove-trailing-separator": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+          "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
           "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
           "dev": true
         },
         "repeating": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
             "is-finite": "^1.0.0"
@@ -6693,22 +16136,26 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6717,7 +16164,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
             "glob": "^7.0.5"
@@ -6725,17 +16173,20 @@
         },
         "semver": {
           "version": "5.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -6743,27 +16194,32 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+          "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
           "dev": true,
           "requires": {
             "foreground-child": "^1.5.6",
@@ -6776,7 +16232,8 @@
         },
         "spdx-correct": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
           "dev": true,
           "requires": {
             "spdx-license-ids": "^1.0.2"
@@ -6784,17 +16241,20 @@
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -6803,17 +16263,20 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -6823,7 +16286,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -6831,7 +16295,8 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
             "is-utf8": "^0.2.0"
@@ -6839,17 +16304,20 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "test-exclude": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+          "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
           "dev": true,
           "requires": {
             "arrify": "^1.0.1",
@@ -6861,17 +16329,20 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         },
         "trim-right": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
           "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6882,7 +16353,8 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6896,13 +16368,15 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "dev": true,
           "optional": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
             "spdx-correct": "~1.0.0",
@@ -6911,7 +16385,8 @@
         },
         "which": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -6919,23 +16394,27 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -6944,7 +16423,8 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -6956,12 +16436,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -6971,17 +16453,20 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "10.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
           "dev": true,
           "requires": {
             "cliui": "^3.2.0",
@@ -7000,7 +16485,8 @@
           "dependencies": {
             "cliui": {
               "version": "3.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
               "requires": {
                 "string-width": "^1.0.1",
@@ -7010,7 +16496,8 @@
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
@@ -7024,7 +16511,8 @@
         },
         "yargs-parser": {
           "version": "8.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+          "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -7032,7 +16520,8 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             }
           }
@@ -7050,47 +16539,6 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
-    "object-copy": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-      "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "object-keys": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
-    },
-    "object-visit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-      "requires": {
-        "isobject": "^3.0.0"
-      }
-    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -7099,14 +16547,6 @@
       "requires": {
         "for-own": "^0.1.4",
         "is-extendable": "^0.1.1"
-      }
-    },
-    "object.pick": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-      "requires": {
-        "isobject": "^3.0.1"
       }
     },
     "observable-to-promise": {
@@ -7171,24 +16611,11 @@
       "integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI=",
       "dev": true
     },
-    "optjs": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
-    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "^1.0.0"
-      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -7214,19 +16641,19 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-      "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "requires": {
-        "p-try": "^2.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-timeout": {
@@ -7239,9 +16666,9 @@
       }
     },
     "p-try": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "package-hash": {
       "version": "2.0.0",
@@ -7332,16 +16759,6 @@
       "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
       "dev": true
     },
-    "pascalcase": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
-    },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
-    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -7350,7 +16767,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -7384,14 +16802,6 @@
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
-      }
-    },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "requires": {
-        "pify": "^3.0.0"
       }
     },
     "performance-now": {
@@ -7429,15 +16839,6 @@
         "load-json-file": "^4.0.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -7449,40 +16850,6 @@
             "pify": "^3.0.0",
             "strip-bom": "^3.0.0"
           }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
         },
         "parse-json": {
           "version": "4.0.0",
@@ -7503,51 +16870,6 @@
       "dev": true,
       "requires": {
         "find-up": "^2.1.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        }
       }
     },
     "plur": {
@@ -7557,120 +16879,6 @@
       "dev": true,
       "requires": {
         "irregular-plurals": "^1.0.0"
-      }
-    },
-    "posix-character-classes": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
-    },
-    "power-assert": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.6.0.tgz",
-      "integrity": "sha512-nDb6a+p2C7Wj8Y2zmFtLpuv+xobXz4+bzT5s7dr0nn71tLozn7nRMQqzwbefzwZN5qOm0N7Cxhw4kXP75xboKA==",
-      "requires": {
-        "define-properties": "^1.1.2",
-        "empower": "^1.3.0",
-        "power-assert-formatter": "^1.4.1",
-        "universal-deep-strict-equal": "^1.2.1",
-        "xtend": "^4.0.0"
-      }
-    },
-    "power-assert-context-formatter": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.2.0.tgz",
-      "integrity": "sha512-HLNEW8Bin+BFCpk/zbyKwkEu9W8/zThIStxGo7weYcFkKgMuGCHUJhvJeBGXDZf0Qm2xis4pbnnciGZiX0EpSg==",
-      "requires": {
-        "core-js": "^2.0.0",
-        "power-assert-context-traversal": "^1.2.0"
-      }
-    },
-    "power-assert-context-reducer-ast": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.2.0.tgz",
-      "integrity": "sha512-EgOxmZ/Lb7tw4EwSKX7ZnfC0P/qRZFEG28dx/690qvhmOJ6hgThYFm5TUWANDLK5NiNKlPBi5WekVGd2+5wPrw==",
-      "requires": {
-        "acorn": "^5.0.0",
-        "acorn-es7-plugin": "^1.0.12",
-        "core-js": "^2.0.0",
-        "espurify": "^1.6.0",
-        "estraverse": "^4.2.0"
-      }
-    },
-    "power-assert-context-traversal": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.2.0.tgz",
-      "integrity": "sha512-NFoHU6g2umNajiP2l4qb0BRWD773Aw9uWdWYH9EQsVwIZnog5bd2YYLFCVvaxWpwNzWeEfZIon2xtyc63026pQ==",
-      "requires": {
-        "core-js": "^2.0.0",
-        "estraverse": "^4.1.0"
-      }
-    },
-    "power-assert-formatter": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz",
-      "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
-      "requires": {
-        "core-js": "^2.0.0",
-        "power-assert-context-formatter": "^1.0.7",
-        "power-assert-context-reducer-ast": "^1.0.7",
-        "power-assert-renderer-assertion": "^1.0.7",
-        "power-assert-renderer-comparison": "^1.0.7",
-        "power-assert-renderer-diagram": "^1.0.7",
-        "power-assert-renderer-file": "^1.0.7"
-      }
-    },
-    "power-assert-renderer-assertion": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.2.0.tgz",
-      "integrity": "sha512-3F7Q1ZLmV2ZCQv7aV7NJLNK9G7QsostrhOU7U0RhEQS/0vhEqrRg2jEJl1jtUL4ZyL2dXUlaaqrmPv5r9kRvIg==",
-      "requires": {
-        "power-assert-renderer-base": "^1.1.1",
-        "power-assert-util-string-width": "^1.2.0"
-      }
-    },
-    "power-assert-renderer-base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-base/-/power-assert-renderer-base-1.1.1.tgz",
-      "integrity": "sha1-lqZQxv0F7hvB9mtUrWFELIs/Y+s="
-    },
-    "power-assert-renderer-comparison": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.2.0.tgz",
-      "integrity": "sha512-7c3RKPDBKK4E3JqdPtYRE9cM8AyX4LC4yfTvvTYyx8zSqmT5kJnXwzR0yWQLOavACllZfwrAGQzFiXPc5sWa+g==",
-      "requires": {
-        "core-js": "^2.0.0",
-        "diff-match-patch": "^1.0.0",
-        "power-assert-renderer-base": "^1.1.1",
-        "stringifier": "^1.3.0",
-        "type-name": "^2.0.1"
-      }
-    },
-    "power-assert-renderer-diagram": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.2.0.tgz",
-      "integrity": "sha512-JZ6PC+DJPQqfU6dwSmpcoD7gNnb/5U77bU5KgNwPPa+i1Pxiz6UuDeM3EUBlhZ1HvH9tMjI60anqVyi5l2oNdg==",
-      "requires": {
-        "core-js": "^2.0.0",
-        "power-assert-renderer-base": "^1.1.1",
-        "power-assert-util-string-width": "^1.2.0",
-        "stringifier": "^1.3.0"
-      }
-    },
-    "power-assert-renderer-file": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.2.0.tgz",
-      "integrity": "sha512-/oaVrRbeOtGoyyd7e4IdLP/jIIUFJdqJtsYzP9/88R39CMnfF/S/rUc8ZQalENfUfQ/wQHu+XZYRMaCEZmEesg==",
-      "requires": {
-        "power-assert-renderer-base": "^1.1.1"
-      }
-    },
-    "power-assert-util-string-width": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.2.0.tgz",
-      "integrity": "sha512-lX90G0igAW0iyORTILZ/QjZWsa1MZ6VVY3L0K86e2eKun3S4LKPH4xZIl8fdeMYLfOjkaszbNSzf1uugLeAm2A==",
-      "requires": {
-        "eastasianwidth": "^0.2.0"
       }
     },
     "prepend-http": {
@@ -7712,26 +16920,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-    },
-    "protobufjs": {
-      "version": "6.8.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.6.tgz",
-      "integrity": "sha512-eH2OTP9s55vojr3b7NBaF9i4WhWPkv/nq55nznWNp/FomKrLViprUcqnBjHph2tFQ+7KciGPTPsVWGz0SOhL0Q==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^3.0.32",
-        "@types/node": "^8.9.4",
-        "long": "^4.0.0"
-      }
     },
     "proxyquire": {
       "version": "2.0.1",
@@ -7875,51 +17063,6 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^2.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        }
       }
     },
     "readable-stream": {
@@ -7990,15 +17133,6 @@
         "is-equal-shallow": "^0.1.3"
       }
     },
-    "regex-not": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-      "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
-      }
-    },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
@@ -8062,12 +17196,14 @@
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -8142,11 +17278,6 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
-    "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-    },
     "responselike": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
@@ -8165,11 +17296,6 @@
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
       }
-    },
-    "ret": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "retry-axios": {
       "version": "0.3.2",
@@ -8199,14 +17325,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "safe-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-      "requires": {
-        "ret": "~0.1.10"
-      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -8251,27 +17369,6 @@
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
-    "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
-      }
-    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -8291,13 +17388,12 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.1.3.tgz",
-      "integrity": "sha512-yeTza8xIZZdiXntCHJAzKll/sSYE+DuJOS8hiSapzaLqdW8eCNVVC9je9SZYYTkPm2bLts9x6UYxwuMAVVrM6Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.0.1.tgz",
+      "integrity": "sha512-rfszhNcfamK2+ofIPi9XqeH89pH7KGDcAtM+F9CsjHXOK3jzWG99vyhyD2V+r7s4IipmWcWUFYq4ftZ9/Eu2Wg==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "^2.0.0",
-        "@sinonjs/samsam": "^2.0.0",
         "diff": "^3.5.0",
         "lodash.get": "^4.4.2",
         "lolex": "^2.4.2",
@@ -8309,7 +17405,8 @@
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
     },
     "slice-ansi": {
       "version": "1.0.0",
@@ -8339,103 +17436,6 @@
       "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
       "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
     },
-    "snapdragon": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-      "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
-      }
-    },
-    "snapdragon-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-      "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
-      }
-    },
-    "snapdragon-util": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-      "requires": {
-        "kind-of": "^3.2.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -8448,19 +17448,8 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-    },
-    "source-map-resolve": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-      "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
-      }
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.5.6",
@@ -8479,11 +17468,6 @@
           "dev": true
         }
       }
-    },
-    "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spdx-correct": {
       "version": "3.0.0",
@@ -8526,14 +17510,6 @@
         "is-stream-ended": "^0.1.0"
       }
     },
-    "split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "requires": {
-        "extend-shallow": "^3.0.0"
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -8561,25 +17537,6 @@
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
       "dev": true
-    },
-    "static-extend": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-      "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        }
-      }
     },
     "stream-events": {
       "version": "1.0.4",
@@ -8627,16 +17584,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "stringifier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
-      "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
-      "requires": {
-        "core-js": "^2.0.0",
-        "traverse": "^0.6.6",
-        "type-name": "^2.0.1"
       }
     },
     "strip-ansi": {
@@ -8833,44 +17780,6 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
-    "to-object-path": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "to-regex": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-      "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
-      }
-    },
-    "to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-      "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
-      }
-    },
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
@@ -8878,11 +17787,6 @@
       "requires": {
         "punycode": "^1.4.1"
       }
-    },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -8921,11 +17825,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
-    },
-    "type-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
-      "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -9005,38 +17904,6 @@
       "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
       "dev": true
     },
-    "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
-      }
-    },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
@@ -9056,57 +17923,11 @@
         "uid2": "0.0.3"
       }
     },
-    "universal-deep-strict-equal": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/universal-deep-strict-equal/-/universal-deep-strict-equal-1.2.2.tgz",
-      "integrity": "sha1-DaSsL3PP95JMgfpN4BjKViyisKc=",
-      "requires": {
-        "array-filter": "^1.0.0",
-        "indexof": "0.0.1",
-        "object-keys": "^1.0.0"
-      }
-    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
-    },
-    "unset-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-      "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            }
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        }
-      }
     },
     "unzip-response": {
       "version": "2.0.1",
@@ -9132,11 +17953,6 @@
         "xdg-basedir": "^3.0.0"
       }
     },
-    "urix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
-    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -9151,14 +17967,6 @@
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
       "dev": true
-    },
-    "use": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-      "requires": {
-        "kind-of": "^6.0.2"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -9251,11 +18059,6 @@
         }
       }
     },
-    "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
-    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -9323,11 +18126,6 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
     },
-    "xregexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
-    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -9344,13 +18142,13 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
-      "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.0.tgz",
+      "integrity": "sha512-wxkoyGB8193wsR6UhjzVQ76VgXx5wLJvGsBd70tuLabLFIDx/Pq9+GFGY3aoWZ8zDMK6KrmdjlUf/h/SMv+eOA==",
       "requires": {
         "cliui": "^4.0.0",
-        "decamelize": "^2.0.0",
-        "find-up": "^3.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
         "get-caller-file": "^1.0.1",
         "os-locale": "^2.0.0",
         "require-directory": "^2.1.1",
@@ -9359,7 +18157,7 @@
         "string-width": "^2.0.0",
         "which-module": "^2.0.0",
         "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^10.1.0"
+        "yargs-parser": "^10.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9375,14 +18173,6 @@
             "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0",
             "wrap-ansi": "^2.0.0"
-          }
-        },
-        "decamelize": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-          "requires": {
-            "xregexp": "4.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -9420,9 +18210,9 @@
       }
     },
     "yargs-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz",
+      "integrity": "sha512-+DHejWujTVYeMHLff8U96rLc4uE4Emncoftvn5AjhB1Jw1pWxLzgBUT/WYbPrHmy6YPEBTZQx5myHhVcuuu64g==",
       "requires": {
         "camelcase": "^4.1.0"
       },

--- a/samples/package.json
+++ b/samples/package.json
@@ -12,7 +12,7 @@
     "test": "ava -T 20s --verbose system-test/*.test.js"
   },
   "dependencies": {
-    "@google-cloud/speech": "^1.5.0",
+    "@google-cloud/speech": "2.0.0",
     "@google-cloud/storage": "^1.7.0",
     "node-record-lpcm16": "^0.3.0",
     "yargs": "^12.0.0"


### PR DESCRIPTION
# Release 2.0.0

# Changes
- Update v1p1beta1 version to support new features (MULTICHANNEL, speaker diarization, word confidence) (#110)
- Drop support for node.js 4.x and 9.x (#106)
- Update google-gax to v0.17.0 and address breaking changes
- Configure Renovate (#91)
- Add support for node.js 10.x (#75)
    

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
