### PR TITLE
fix: Parse response errors and emit as error event.

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "test": "npm run cover"
   },
   "dependencies": {
+    "@google-cloud/common": "^0.24.0",
     "extend": "^3.0.1",
     "google-gax": "^0.20.0",
     "google-proto-files": "^0.16.0",
@@ -100,6 +101,7 @@
     "nyc": "^13.0.0",
     "power-assert": "^1.6.0",
     "prettier": "^1.13.5",
+    "proxyquire": "^2.1.0",
     "safe-buffer": "^5.1.2",
     "sinon": "^6.0.0"
   }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,6 +16,7 @@
 
 'use strict';
 
+var common = require('@google-cloud/common');
 var pumpify = require('pumpify');
 var streamEvents = require('stream-events');
 var through = require('through2');
@@ -108,7 +109,14 @@ module.exports = () => {
           next(null, payload);
         }),
         requestStream,
-        through.obj(),
+        through.obj((response, enc, next) => {
+          if (response.error) {
+            next(new common.util.ApiError(response.error));
+            return;
+          }
+
+          next(null, response);
+        }),
       ]);
     });
 

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -18,14 +18,36 @@
 
 var assert = require('assert');
 var Buffer = require('safe-buffer').Buffer;
+var common = require('@google-cloud/common');
+var proxyquire = require('proxyquire');
 var sinon = require('sinon');
 var stream = require('stream');
 
-var speech = require('../');
-
 describe('Speech helper methods', () => {
-  var sandbox = sinon.sandbox.create();
   var client;
+  var FakeApiErrorOverride;
+  var sandbox = sinon.createSandbox();
+  var speech;
+
+  class FakeApiError extends common.util.ApiError {
+    constructor(error) {
+      if (FakeApiErrorOverride) {
+        return FakeApiErrorOverride(error);
+      }
+    }
+  }
+
+  before(() => {
+    speech = proxyquire('../', {
+      './helpers.js': proxyquire('../src/helpers.js', {
+        '@google-cloud/common': {
+          util: {
+            ApiError: FakeApiError,
+          },
+        },
+      }),
+    });
+  });
 
   beforeEach(() => {
     client = new speech.v1.SpeechClient();
@@ -103,6 +125,33 @@ describe('Speech helper methods', () => {
       });
 
       requestStream.emit('error', error);
+    });
+
+    it('destroys the user stream when the response contains an error', done => {
+      // Stub the underlying _streamingRecognize method to just return
+      // a bogus stream.
+      var requestStream = new stream.PassThrough({objectMode: true});
+      sandbox
+        .stub(client._innerApiCalls, 'streamingRecognize')
+        .returns(requestStream);
+
+      var userStream = client.streamingRecognize(CONFIG, OPTIONS);
+
+      var error = {};
+      var fakeApiError = {};
+
+      FakeApiErrorOverride = err => {
+        assert.strictEqual(err, error);
+        return fakeApiError;
+      };
+
+      userStream.once('error', err => {
+        assert.strictEqual(err, fakeApiError);
+        done();
+      });
+
+      userStream.emit('writing');
+      requestStream.end({error});
     });
 
     it('re-emits response from the request stream', done => {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -31,6 +31,8 @@ describe('Speech helper methods', () => {
 
   class FakeApiError extends common.util.ApiError {
     constructor(error) {
+      super();
+
       if (FakeApiErrorOverride) {
         return FakeApiErrorOverride(error);
       }


### PR DESCRIPTION
## ⚠️ Breaking Change

I noticed that a response object from `streamingRecognize()` can contain an errors property. That leads to:

```js
myAudio.pipe(speech.streamingRecognize())
  .on('error', handleFailures)
  .on('data', resp => {
    // This event is like a success event.
    // So I wouldn't expect to see an error here, but! It happens.
    if (resp.error) {
      // Handle error.
    }
  })
```

This PR looks for the `error` property on an API response, and ends the stream with that error (so that their `.on('error', handleFailures)` event listener will execute).