### PR TITLE
fix: send streamingConfig as a separate write before audioContent

### DIFF
--- a/samples/recognize.js
+++ b/samples/recognize.js
@@ -683,7 +683,7 @@ function syncRecognizeWithEnhancedModel(
   // [END speech_transcribe_enhanced_model]
 }
 
-require(`yargs`)  // eslint-disable-line
+require(`yargs`) // eslint-disable-line
   .demand(1)
   .command(
     `sync <filename>`,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -64,9 +64,8 @@ module.exports = () => {
    * stream.write(request);
    */
   methods.streamingRecognize = function(streamingConfig, options) {
-    if (options === undefined) {
-      options = {};
-    }
+    options = options || {};
+    streamingConfig = streamingConfig || {};
 
     // Format the audio content as input request for pipeline
     const recognizeStream = streamEvents(pumpify.obj());
@@ -95,7 +94,11 @@ module.exports = () => {
         // Format the user's input.
         // This entails that the user sends raw audio; it is wrapped in
         // the appropriate request structure.
-        through.obj((audioContent, _, next) => next(null, {audioContent})),
+        through.obj((audioContent, _, next) => {
+          if (audioContent !== undefined) {
+            next(null, {audioContent});
+          }
+        }),
         requestStream,
         through.obj((response, enc, next) => {
           if (response.error) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -102,9 +102,12 @@ module.exports = () => {
             payload.streamingConfig = config;
           }
 
+          let payload = {};
           if (Object.keys(obj || {}).length) {
             payload.audioContent = obj;
           }
+
+          firstMessage = false;
 
           next(null, payload);
         }),

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -97,7 +97,10 @@ module.exports = () => {
         through.obj((audioContent, _, next) => {
           if (audioContent !== undefined) {
             next(null, {audioContent});
+            return;
           }
+
+          next();
         }),
         requestStream,
         through.obj((response, enc, next) => {

--- a/synth.py
+++ b/synth.py
@@ -47,6 +47,11 @@ for version in versions:
         "stream\.write\(request\)",
         "stream.write()")
 
+    s.replace(
+        f"test/gapic-{version}.js",
+        "// Mock request\n\s*const request = {};",
+        "")
+
 templates = common_templates.node_library()
 # TODO: remove excludes once var's are converted to const/let
 s.copy(templates, excludes=['.eslintrc.yml'])

--- a/synth.py
+++ b/synth.py
@@ -35,12 +35,24 @@ for version in versions:
         excludes=['package.json', 'README.md', 'src/index.js',]
     )
 
-templates = common_templates.node_library(package_name="@google-cloud/speech")
-s.copy(templates)
+    # Manual helper methods overrides the streaming API so that it
+    # accepts streamingConfig when calling streamingRecognize. Fix
+    # the gapic tests to use the overridden method signature.
+    s.replace( f"test/gapic-{version}.js",
+        "(mockBidiStreamingGrpcMethod\()request",
+        r"\1{ streamingConfig: {} }")
+
+    s.replace(
+        f"test/gapic-{version}.js",
+        "stream\.write\(request\)",
+        "stream.write()")
+
+templates = common_templates.node_library()
+# TODO: remove excludes once var's are converted to const/let
+s.copy(templates, excludes=['.eslintrc.yml'])
 
 #
 # Node.js specific cleanup
 #
 subprocess.run(['npm', 'install'])
 subprocess.run(['npm', 'run', 'prettier'])
-subprocess.run(['npm', 'run', 'lint'])

--- a/test/gapic-v1.js
+++ b/test/gapic-v1.js
@@ -224,9 +224,6 @@ describe('SpeechClient', () => {
         projectId: 'bogus',
       });
 
-      // Mock request
-      const request = {};
-
       // Mock response
       const expectedResponse = {};
 
@@ -254,9 +251,6 @@ describe('SpeechClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
-
-      // Mock request
-      const request = {};
 
       // Mock Grpc layer
       client._innerApiCalls.streamingRecognize = mockBidiStreamingGrpcMethod(

--- a/test/gapic-v1.js
+++ b/test/gapic-v1.js
@@ -232,7 +232,7 @@ describe('SpeechClient', () => {
 
       // Mock Grpc layer
       client._innerApiCalls.streamingRecognize = mockBidiStreamingGrpcMethod(
-        request,
+        {streamingConfig: {}},
         expectedResponse
       );
 
@@ -246,7 +246,7 @@ describe('SpeechClient', () => {
           done(err);
         });
 
-      stream.write(request);
+      stream.write();
     });
 
     it('invokes streamingRecognize with error', done => {
@@ -260,7 +260,7 @@ describe('SpeechClient', () => {
 
       // Mock Grpc layer
       client._innerApiCalls.streamingRecognize = mockBidiStreamingGrpcMethod(
-        request,
+        {streamingConfig: {}},
         null,
         error
       );
@@ -276,7 +276,7 @@ describe('SpeechClient', () => {
           done();
         });
 
-      stream.write(request);
+      stream.write();
     });
   });
 });

--- a/test/gapic-v1p1beta1.js
+++ b/test/gapic-v1p1beta1.js
@@ -224,9 +224,6 @@ describe('SpeechClient', () => {
         projectId: 'bogus',
       });
 
-      // Mock request
-      const request = {};
-
       // Mock response
       const expectedResponse = {};
 
@@ -254,9 +251,6 @@ describe('SpeechClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
-
-      // Mock request
-      const request = {};
 
       // Mock Grpc layer
       client._innerApiCalls.streamingRecognize = mockBidiStreamingGrpcMethod(

--- a/test/gapic-v1p1beta1.js
+++ b/test/gapic-v1p1beta1.js
@@ -232,7 +232,7 @@ describe('SpeechClient', () => {
 
       // Mock Grpc layer
       client._innerApiCalls.streamingRecognize = mockBidiStreamingGrpcMethod(
-        request,
+        {streamingConfig: {}},
         expectedResponse
       );
 
@@ -246,7 +246,7 @@ describe('SpeechClient', () => {
           done(err);
         });
 
-      stream.write(request);
+      stream.write();
     });
 
     it('invokes streamingRecognize with error', done => {
@@ -260,7 +260,7 @@ describe('SpeechClient', () => {
 
       // Mock Grpc layer
       client._innerApiCalls.streamingRecognize = mockBidiStreamingGrpcMethod(
-        request,
+        {streamingConfig: {}},
         null,
         error
       );
@@ -276,7 +276,7 @@ describe('SpeechClient', () => {
           done();
         });
 
-      stream.write(request);
+      stream.write();
     });
   });
 });

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -184,6 +184,7 @@ describe('Speech helper methods', () => {
       // Stub the underlying _streamingRecognize method to just return
       // a bogus stream.
       const requestStream = new stream.PassThrough({objectMode: true});
+
       sandbox
         .stub(client._innerApiCalls, 'streamingRecognize')
         .returns(requestStream);
@@ -191,12 +192,19 @@ describe('Speech helper methods', () => {
       const userStream = client.streamingRecognize(CONFIG, OPTIONS);
       const audioContent = Buffer.from('audio content');
 
+      var count = 0;
       requestStream._write = (data, enc, next) => {
-        assert.deepStrictEqual(data, {
-          audioContent: audioContent,
-          streamingConfig: CONFIG,
-        });
-        setImmediate(done);
+        if (count === 0)
+          assert.deepStrictEqual(data, {
+            streamingConfig: CONFIG,
+          });
+        else if (count === 1) {
+          assert.deepStrictEqual(data, {
+            audioContent: audioContent,
+          });
+          setImmediate(done);
+        }
+        count++;
         next(null, data);
       };
 

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -192,7 +192,7 @@ describe('Speech helper methods', () => {
       const userStream = client.streamingRecognize(CONFIG, OPTIONS);
       const audioContent = Buffer.from('audio content');
 
-      var count = 0;
+      let count = 0;
       requestStream._write = (data, enc, next) => {
         if (count === 0)
           assert.deepStrictEqual(data, {


### PR DESCRIPTION
Fixes #173.
Fixes #182.

I personally am not fan of modifying test methods generated by gapic, since the gapic tests should test the underlying (not helper-wrapped) methods.

So I tried to just require the underlying source via `require('../src/v1')`, the tests would pass if it's not run along with `helpers.test.js` (`npx mocha test/gapic-{v1|v1beta1}.js`). Somehow requiring `helpers.js` modifies the actual exports in the gapic generated libs - so when I run `npm test` it fails.