### PR TITLE
refactor(helpers): send streamingConfig is separate payload from audio

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -87,7 +87,9 @@ module.exports = () => {
     // config) is delayed until we get the first burst of data.
     recognizeStream.once('writing', () => {
       // The first message should contain the streaming config.
-      const firstMessage = true;
+      if (config) {
+        requestStream.write({streamingConfig: config});
+      }
 
       // Set up appropriate piping between the stream returned by
       // the underlying API method and the one that we return.
@@ -97,12 +99,8 @@ module.exports = () => {
         // the appropriate request structure.
         through.obj((obj, _, next) => {
           const payload = {};
-          if (firstMessage && config !== undefined) {
-            // Write the initial configuration to the stream.
-            payload.streamingConfig = config;
-          }
 
-          if (Object.keys(obj || {}).length) {
+          if (Buffer.isBuffer(obj)) {
             payload.audioContent = obj;
           }
 


### PR DESCRIPTION
Fixes #173
Fixes #182

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

I'm definitely going to need some help from anyone familiar with Speech. From what I can tell the API  didn't like it when we tried to bundle both the `streamingConfig` and the `audioContent` in the same request. It also appeared that we were sending the `streamingConfig` on every write (`firstMessage` never gets set to `false`), which doesn't appear to be necessary.

I still need to write unit tests for the proposed changes, but figured I'd hold off incase there's an obvious no-no here. 😄 