### PR TITLE
fix: Pin @types/sinon to last compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "power-assert": "^1.6.0",
     "prettier": "^1.13.5",
     "proxyquire": "^2.1.0",
-    "sinon": "^7.0.0"
+    "sinon": "^7.0.0",
+    "@types/sinon": "5.0.5"
   }
 }


### PR DESCRIPTION
@types/sinon had an update over the weekend which broke many of our tests. The *real* fix is [something like this](https://github.com/googleapis/nodejs-spanner/pull/441/files), but for now, this should fix our broken CI and give us some breathing room.