### PR TITLE
fix: added clarity around needing SoX for 'streamingMicRecognize' sample

### DIFF
--- a/samples/recognize.js
+++ b/samples/recognize.js
@@ -415,7 +415,8 @@ function streamingMicRecognize(encoding, sampleRateHertz, languageCode) {
       )
     );
 
-  // Start recording and send the microphone input to the Speech API
+  // Start recording and send the microphone input to the Speech API.
+  // Ensure SoX is installed, see https://www.npmjs.com/package/node-record-lpcm16#dependencies
   recorder
     .record({
       sampleRateHertz: sampleRateHertz,


### PR DESCRIPTION
In response to `b/143971370`, make the sample a bit clearer
