### PR TITLE
docs(samples): moved export-to-gcs sample to v1

### DIFF
--- a/samples/export-to-storage.v1p1beta1.js
+++ b/samples/export-to-storage.v1p1beta1.js
@@ -36,7 +36,7 @@ function main(
   // const languageCode = 'BCP-47_LANGUAGE_CODE_OF_AUDIO';
 
   // Imports the Speech-to-Text client library
-  const speech = require('@google-cloud/speech').v1p1beta1;
+  const speech = require('@google-cloud/speech');
   const {Storage} = require('@google-cloud/storage');
   const path = require('path');
   const fsp = require('fs.promises');


### PR DESCRIPTION
pr that transitions the export-to-gcs to v1, as discussed [here](https://buganizer.corp.google.com/issues/188835214).