### PR TITLE
fix: flaky system test

### DIFF
--- a/system-test/speech_system_test.js
+++ b/system-test/speech_system_test.js
@@ -95,9 +95,9 @@ describe('SpeechClient system test default', () => {
     const stream = client.streamingRecognize(request);
     let gotResponse = false;
     stream.on('data', response => {
-      assert.strictEqual(
+      assert.match(
         response.results[0].alternatives[0].transcript,
-        'test of streaming recognized call'
+        /test of streaming.*call/
       );
       gotResponse = true;
     });

--- a/system-test/speech_system_test_v1.js
+++ b/system-test/speech_system_test_v1.js
@@ -95,9 +95,9 @@ describe('SpeechClient system test v1', () => {
     const stream = client.streamingRecognize(request);
     let gotResponse = false;
     stream.on('data', response => {
-      assert.strictEqual(
+      assert.match(
         response.results[0].alternatives[0].transcript,
-        'test of streaming recognized call'
+        /test of streaming.*call/
       );
       gotResponse = true;
     });

--- a/system-test/speech_system_test_v1p1beta1.js
+++ b/system-test/speech_system_test_v1p1beta1.js
@@ -95,9 +95,9 @@ describe('SpeechClient system test v1p1beta1', () => {
     const stream = client.streamingRecognize(request);
     let gotResponse = false;
     stream.on('data', response => {
-      assert.strictEqual(
+      assert.match(
         response.results[0].alternatives[0].transcript,
-        'test of streaming recognized call'
+        /test of streaming.*call/
       );
       gotResponse = true;
     });

--- a/system-test/speech_typescript_system_test.ts
+++ b/system-test/speech_typescript_system_test.ts
@@ -107,7 +107,7 @@ describe('SpeechClient TypeScript system test default', () => {
     stream.on(
       'data',
       (response: google.cloud.speech.v1.IStreamingRecognizeResponse) => {
-        assert.doesNotMatch(
+        assert.match(
           response.results![0].alternatives![0].transcript ?? '',
           /test of streaming.*call/
         );

--- a/system-test/speech_typescript_system_test.ts
+++ b/system-test/speech_typescript_system_test.ts
@@ -107,9 +107,9 @@ describe('SpeechClient TypeScript system test default', () => {
     stream.on(
       'data',
       (response: google.cloud.speech.v1.IStreamingRecognizeResponse) => {
-        assert.strictEqual(
-          response.results![0].alternatives![0].transcript,
-          'test of streaming recognized call'
+        assert.doesNotMatch(
+          response.results![0].alternatives![0].transcript ?? '',
+          /test of streaming.*call/
         );
         gotResponse = true;
       }

--- a/system-test/speech_typescript_system_test_v1.ts
+++ b/system-test/speech_typescript_system_test_v1.ts
@@ -107,7 +107,7 @@ describe('SpeechClient TypeScript system test v1', () => {
     stream.on(
       'data',
       (response: google.cloud.speech.v1.IStreamingRecognizeResponse) => {
-        assert.doesNotMatch(
+        assert.match(
           response.results![0].alternatives![0].transcript ?? '',
           /test of streaming.*call/
         );

--- a/system-test/speech_typescript_system_test_v1.ts
+++ b/system-test/speech_typescript_system_test_v1.ts
@@ -107,9 +107,9 @@ describe('SpeechClient TypeScript system test v1', () => {
     stream.on(
       'data',
       (response: google.cloud.speech.v1.IStreamingRecognizeResponse) => {
-        assert.strictEqual(
-          response.results![0].alternatives![0].transcript,
-          'test of streaming recognized call'
+        assert.doesNotMatch(
+          response.results![0].alternatives![0].transcript ?? '',
+          /test of streaming.*call/
         );
         gotResponse = true;
       }

--- a/system-test/speech_typescript_system_test_v1p1beta1.ts
+++ b/system-test/speech_typescript_system_test_v1p1beta1.ts
@@ -107,9 +107,9 @@ describe('SpeechClient TypeScript system test v1p1beta1', () => {
     stream.on(
       'data',
       (response: google.cloud.speech.v1p1beta1.IStreamingRecognizeResponse) => {
-        assert.strictEqual(
-          response.results![0].alternatives![0].transcript,
-          'test of streaming recognized call'
+        assert.doesNotMatch(
+          response.results![0].alternatives![0].transcript ?? '',
+          /test of streaming.*call/
         );
         gotResponse = true;
       }

--- a/system-test/speech_typescript_system_test_v1p1beta1.ts
+++ b/system-test/speech_typescript_system_test_v1p1beta1.ts
@@ -107,7 +107,7 @@ describe('SpeechClient TypeScript system test v1p1beta1', () => {
     stream.on(
       'data',
       (response: google.cloud.speech.v1p1beta1.IStreamingRecognizeResponse) => {
-        assert.doesNotMatch(
+        assert.match(
           response.results![0].alternatives![0].transcript ?? '',
           /test of streaming.*call/
         );


### PR DESCRIPTION
Method 'streamingRecognize' keep change the return result when recognize the system-test sample recording. 

Copy @SurferJeffAtGoogle #869 to fix the flaky results.
